### PR TITLE
[BE-FIX] 모든 response에서 304 제외 및 로그아웃 처리 위치 변경

### DIFF
--- a/back_end/src/main/java/com/ssafy/stella_trip/security/config/SecurityConfig.java
+++ b/back_end/src/main/java/com/ssafy/stella_trip/security/config/SecurityConfig.java
@@ -11,6 +11,7 @@ import org.springframework.security.config.annotation.authentication.configurati
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -84,10 +85,7 @@ public class SecurityConfig {
         http.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
 
         // 로그아웃은 filter단에서 처리되게끔
-        http.logout(customizer -> customizer.logoutUrl("/user/logout")
-                .invalidateHttpSession(true).logoutSuccessUrl("/")
-                .deleteCookies("JSESSIONID", "loginId", "Authorization")
-        );
+        http.logout(AbstractHttpConfigurer::disable);
         return http.build();
     }
 }

--- a/back_end/src/main/java/com/ssafy/stella_trip/user/dto/response/SignupResponseDTO.java
+++ b/back_end/src/main/java/com/ssafy/stella_trip/user/dto/response/SignupResponseDTO.java
@@ -1,0 +1,14 @@
+package com.ssafy.stella_trip.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class SignupResponseDTO {
+    private int id;
+    private String email;
+    private String name;
+}

--- a/back_end/src/main/java/com/ssafy/stella_trip/user/service/UserService.java
+++ b/back_end/src/main/java/com/ssafy/stella_trip/user/service/UserService.java
@@ -8,6 +8,7 @@ import com.ssafy.stella_trip.user.annotation.PasswordEncoded;
 import com.ssafy.stella_trip.user.dto.UserDTO;
 import com.ssafy.stella_trip.user.dto.UserRole;
 import com.ssafy.stella_trip.user.dto.response.LoginResponseDTO;
+import com.ssafy.stella_trip.user.dto.response.SignupResponseDTO;
 import com.ssafy.stella_trip.user.dto.response.TokenRefreshResponseDTO;
 import com.ssafy.stella_trip.user.exception.SignupFailureException;
 import lombok.RequiredArgsConstructor;
@@ -54,7 +55,7 @@ public class UserService {
      * @param password 비밀번호 (아직 encoding 안됨)
      * @return 회원가입한 유저 정보
      */
-    public UserDTO signup(String name, String email, String password) {
+    public SignupResponseDTO signup(String name, String email, String password) {
         // password 인코딩하기
         String encodedPassword = passwordEncoder.encode(password);
         UserDTO user = UserDTO.builder()
@@ -64,8 +65,9 @@ public class UserService {
                 .role(UserRole.USER)
                 .build();
         int res = userDAO.insertUser(user);
-        if(res > 0)
-            return user;
+        if(res > 0){
+            return new SignupResponseDTO(user.getUserId(), user.getEmail(), user.getName());
+        }
         else throw new SignupFailureException("회원가입에 실패하였습니다.");
     }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #11 

## 📝 작업 내용
- [ ] filter 로그아웃 로직을 controller단에서 처리하도록 변경
- [x] 회원가입시 200 response로 회원정보 반환

## 📑 작업 상세 내용


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 회원가입 완료 시 사용자 ID, 이메일, 이름 정보를 포함한 응답 데이터를 제공합니다.

- **버그 수정**
    - 로그아웃 시 인증 쿠키(Authorization)가 명확하게 삭제되고, 200 OK 상태 코드로 응답하도록 개선되었습니다.

- **기타 변경**
    - 로그아웃 요청 방식이 POST에서 GET으로 변경되었습니다.
    - 회원가입 및 로그아웃 관련 API 응답 형식과 설명이 업데이트되었습니다.
    - Spring Security에서 로그아웃 기능이 비활성화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->