### PR TITLE
[BE-FEAT] 인기순 여행 계획 태그 조회 api

### DIFF
--- a/back_end/src/main/java/com/ssafy/stella_trip/attraction/dto/response/AttractionResponseDTO.java
+++ b/back_end/src/main/java/com/ssafy/stella_trip/attraction/dto/response/AttractionResponseDTO.java
@@ -13,14 +13,12 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class AttractionResponseDTO {
-    @JsonProperty("attraction_id")
     private int attractionId;
     private String name;
     private String image;
     private String address;
-    @JsonProperty("content_type")
     private int contentType;
-    private int like;
+    private int likeCount;
     private double rating;
     private double latitude;
     private double longitude;

--- a/back_end/src/main/java/com/ssafy/stella_trip/attraction/service/AttractionService.java
+++ b/back_end/src/main/java/com/ssafy/stella_trip/attraction/service/AttractionService.java
@@ -306,7 +306,7 @@ public class AttractionService {
                 .image(attraction.getFirstImage1())
                 .address(attraction.getAddr1())
                 .contentType(attraction.getContentTypeId())
-                .like(attraction.getLikeCount())
+                .likeCount(attraction.getLikeCount())
                 .rating(attraction.getRating())
                 .latitude(attraction.getLatitude())
                 .longitude(attraction.getLongitude())

--- a/back_end/src/main/java/com/ssafy/stella_trip/common/config/WebConfig.java
+++ b/back_end/src/main/java/com/ssafy/stella_trip/common/config/WebConfig.java
@@ -1,0 +1,16 @@
+package com.ssafy.stella_trip.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("http://localhost:5173")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH")
+                .allowCredentials(true);
+    }
+}

--- a/back_end/src/main/java/com/ssafy/stella_trip/dao/plan/PlanDAO.java
+++ b/back_end/src/main/java/com/ssafy/stella_trip/dao/plan/PlanDAO.java
@@ -2,6 +2,7 @@ package com.ssafy.stella_trip.dao.plan;
 
 import com.ssafy.stella_trip.plan.dto.PlanDTO;
 import com.ssafy.stella_trip.plan.dto.RouteDTO;
+import com.ssafy.stella_trip.plan.dto.TagDTO;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
@@ -110,4 +111,6 @@ public interface PlanDAO {
     List<PlanDTO> getUserPlansByUserId(@Param("userId") int userId, @Param("offset") int offset, @Param("size") int size);
   
     List<PlanDTO> getLikedPlansByUserId(@Param("userId") int userId, @Param("offset") int offset, @Param("size") int size);
+
+    List<TagDTO> getTagsOrderdByCount(int size);
 }

--- a/back_end/src/main/java/com/ssafy/stella_trip/dao/plan/PlanDAO.java
+++ b/back_end/src/main/java/com/ssafy/stella_trip/dao/plan/PlanDAO.java
@@ -112,5 +112,5 @@ public interface PlanDAO {
   
     List<PlanDTO> getLikedPlansByUserId(@Param("userId") int userId, @Param("offset") int offset, @Param("size") int size);
 
-    List<TagDTO> getTagsOrderdByCount(int size);
+    List<TagDTO> getTagsOrderedByCount(int size);
 }

--- a/back_end/src/main/java/com/ssafy/stella_trip/plan/controller/PlanController.java
+++ b/back_end/src/main/java/com/ssafy/stella_trip/plan/controller/PlanController.java
@@ -3,10 +3,7 @@ package com.ssafy.stella_trip.plan.controller;
 import com.ssafy.stella_trip.common.dto.PageDTO;
 import com.ssafy.stella_trip.common.response.CommonResponse;
 import com.ssafy.stella_trip.plan.dto.request.*;
-import com.ssafy.stella_trip.plan.dto.response.LockSuccessResponseDTO;
-import com.ssafy.stella_trip.plan.dto.response.LockStatusResponseDTO;
-import com.ssafy.stella_trip.plan.dto.response.PlanResponseDTO;
-import com.ssafy.stella_trip.plan.dto.response.RouteResponseDTO;
+import com.ssafy.stella_trip.plan.dto.response.*;
 import com.ssafy.stella_trip.plan.service.PlanService;
 import com.ssafy.stella_trip.security.dto.JwtUserInfo;
 import io.swagger.v3.oas.annotations.Operation;
@@ -17,6 +14,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/v1/plans")
@@ -304,5 +303,17 @@ public class PlanController {
             @AuthenticationPrincipal JwtUserInfo user
     ) {
         return new CommonResponse<>(planService.updateRoute(planId, routeId, routeUpdateRequestDTO, user), HttpStatus.OK);
+    }
+
+    @GetMapping("/tags")
+    @Operation(
+            summary = "여행 계획 태그 목록 조회",
+            description = "조건: 페이지, 사이즈, 검색어, 정렬 방식(id순/인기순)"
+    )
+    @PreAuthorize("permitAll()")
+    public CommonResponse<List<TagResponseDTO>> getTags(
+            @RequestParam(value = "size", defaultValue = "20") int size
+    ) {
+        return new CommonResponse<>(planService.getPopularTags(size), HttpStatus.OK);
     }
 }

--- a/back_end/src/main/java/com/ssafy/stella_trip/plan/dto/TagDTO.java
+++ b/back_end/src/main/java/com/ssafy/stella_trip/plan/dto/TagDTO.java
@@ -10,4 +10,5 @@ import lombok.NoArgsConstructor;
 public class TagDTO {
     private int tagId;
     private String name;
+    private int count;
 }

--- a/back_end/src/main/java/com/ssafy/stella_trip/plan/dto/response/PlanResponseDTO.java
+++ b/back_end/src/main/java/com/ssafy/stella_trip/plan/dto/response/PlanResponseDTO.java
@@ -16,21 +16,15 @@ import java.util.List;
 @NoArgsConstructor
 @SuperBuilder
 public class PlanResponseDTO {
-    @JsonProperty("plan_id")
     private int planId;
     private String title;
     private String description;
     @JsonRawValue
     private String stella;
-    @JsonProperty("start_date")
     private LocalDate startDate;
-    @JsonProperty("end_date")
     private LocalDate endDate;
-    @JsonProperty("like_count")
     private int likeCount;
-    @JsonProperty("is_public")
     private boolean isPublic;
-    @JsonProperty("plan_writers")
     private List<WriterResponseDTO> planWriters;
     private List<TagResponseDTO> tags;
     private boolean liked;

--- a/back_end/src/main/java/com/ssafy/stella_trip/plan/dto/response/TagResponseDTO.java
+++ b/back_end/src/main/java/com/ssafy/stella_trip/plan/dto/response/TagResponseDTO.java
@@ -10,7 +10,7 @@ import lombok.Setter;
 @AllArgsConstructor
 @Builder
 public class TagResponseDTO {
-    @JsonProperty("tag_id")
     private int tagId;
     private String name;
+    private int count;
 }

--- a/back_end/src/main/java/com/ssafy/stella_trip/plan/dto/response/WriterResponseDTO.java
+++ b/back_end/src/main/java/com/ssafy/stella_trip/plan/dto/response/WriterResponseDTO.java
@@ -11,7 +11,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Builder
 public class WriterResponseDTO {
-    @JsonProperty("user_id")
     private int userId;
     private String name;
 }

--- a/back_end/src/main/java/com/ssafy/stella_trip/plan/service/PlanService.java
+++ b/back_end/src/main/java/com/ssafy/stella_trip/plan/service/PlanService.java
@@ -2,6 +2,7 @@ package com.ssafy.stella_trip.plan.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.ssafy.stella_trip.common.dto.PageDTO;
+import com.ssafy.stella_trip.common.util.PaginationUtils;
 import com.ssafy.stella_trip.dao.plan.PlanDAO;
 import com.ssafy.stella_trip.dao.user.UserDAO;
 import com.ssafy.stella_trip.plan.dto.ConstellationDTO;
@@ -491,5 +492,21 @@ public class PlanService {
                 .sorted()
                 .forEach(date -> routeResponseDTOMap.get(date).sort(Comparator.comparingInt(RouteResponseDTO::getOrder)));
         return routeResponseDTOMap;
+    }
+
+    private TagResponseDTO convertTagToResponse(TagDTO tagDTO) {
+        return TagResponseDTO.builder()
+                .tagId(tagDTO.getTagId())
+                .name(tagDTO.getName())
+                .count(tagDTO.getCount())
+                .build();
+    }
+
+    public List<TagResponseDTO> getPopularTags(int size) {
+        if(size < 1) {
+            size = 10;
+        }
+
+        return planDAO.getTagsOrderdByCount(size).stream().map((tagDTO) -> convertTagToResponse(tagDTO)).toList();
     }
 }

--- a/back_end/src/main/java/com/ssafy/stella_trip/plan/service/PlanService.java
+++ b/back_end/src/main/java/com/ssafy/stella_trip/plan/service/PlanService.java
@@ -507,6 +507,6 @@ public class PlanService {
             size = 10;
         }
 
-        return planDAO.getTagsOrderdByCount(size).stream().map((tagDTO) -> convertTagToResponse(tagDTO)).toList();
+        return planDAO.getTagsOrderedByCount(size).stream().map((tagDTO) -> convertTagToResponse(tagDTO)).toList();
     }
 }

--- a/back_end/src/main/java/com/ssafy/stella_trip/user/service/UserProfileService.java
+++ b/back_end/src/main/java/com/ssafy/stella_trip/user/service/UserProfileService.java
@@ -287,7 +287,7 @@ public class UserProfileService {
                 .image(attraction.getFirstImage1())
                 .address(attraction.getAddr1())
                 .contentType(attraction.getContentTypeId())
-                .like(attraction.getLikeCount())
+                .likeCount(attraction.getLikeCount())
                 .rating(attraction.getRating())
                 .latitude(attraction.getLatitude())
                 .longitude(attraction.getLongitude())

--- a/back_end/src/main/resources/mappers/Plan.xml
+++ b/back_end/src/main/resources/mappers/Plan.xml
@@ -35,6 +35,7 @@
         <collection property="tags" ofType="com.ssafy.stella_trip.plan.dto.TagDTO">
             <id column="tag_id" property="tagId"/>
             <result column="tag_name" property="name"/>
+            <result column="tag_count" property="count"/>
         </collection>
 
         <!-- Lazy loading: routes -->
@@ -399,5 +400,19 @@
         FROM plan p
         JOIN liked_plan fp ON p.plan_id = fp.plan_id
         WHERE fp.user_id = #{userId}
+    </select>
+
+    <resultMap id="TagMap" type="com.ssafy.stella_trip.plan.dto.TagDTO">
+        <id column="tag_id" property="tagId"/>
+        <result column="name" property="name"/>
+        <result column="tag_count" property="count"/>
+    </resultMap>
+
+    <select id="getTagsOrderdByCount" resultMap="TagMap">
+        SELECT
+        *
+        from tag
+        order by tag_count desc
+        limit #{size}
     </select>
 </mapper>

--- a/back_end/src/main/resources/mappers/Plan.xml
+++ b/back_end/src/main/resources/mappers/Plan.xml
@@ -408,7 +408,7 @@
         <result column="tag_count" property="count"/>
     </resultMap>
 
-    <select id="getTagsOrderdByCount" resultMap="TagMap">
+    <select id="getTagsOrderedByCount" resultMap="TagMap">
         SELECT
         *
         from tag


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #41 

## 📝 작업 내용
- [x] local host cors 해결
- [x] 메인페이지에 사용되는 api json 키 camelCase 로 변경 
- [x] 여행 계획 태그 조회 api

## 📑 작업 상세 내용
태그는 항상 인기순으로 원하는 개수만큼 가져올 수 있도록 함

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 인기 여행 플랜 태그 목록을 조회할 수 있는 새로운 엔드포인트가 추가되었습니다. 태그는 사용 빈도순으로 정렬되며, 반환 개수를 지정할 수 있습니다.
  - CORS 설정이 추가되어 http://localhost:5173에서의 접근이 허용됩니다.

- **버그 수정**
  - 여러 DTO의 JSON 필드명이 일관성 있게 변경되어, 응답 및 요청 시 필드명이 명확해졌습니다.

- **기타**
  - 태그 관련 DTO에 태그 사용 횟수(count) 필드가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->