### PR TITLE
[FE-FEAT] 메인 페이지 api 연결

### DIFF
--- a/front_end/src/App.vue
+++ b/front_end/src/App.vue
@@ -5,8 +5,9 @@ import GlobalFallback from '@/components/global/GlobalFallback.vue';
 
 const hasError = ref(false);
 
-onErrorCaptured(() => {
+onErrorCaptured(e => {
   hasError.value = true;
+  console.log(e);
 
   return false;
 });

--- a/front_end/src/components/PlanCard/PlanCard.vue
+++ b/front_end/src/components/PlanCard/PlanCard.vue
@@ -1,23 +1,49 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, computed } from 'vue';
 import { Calendar } from 'lucide-vue-next';
 import LikeButton from '@/components/common/LikeButton/LikeButton.vue';
 import Constellation from '@/components/common/Constellation/Constellation.vue';
-import Tag from '@/components/common/Tag/Tag.vue';
+import TagComp from '@/components/common/Tag/Tag.vue';
 import { calculatePeriod, formatLikeCount } from '@/utils/util';
-import type { Plan } from '@/types/type';
+import type { Plan, Tag } from '@/services/api/domains/plan/types';
 
 interface Props {
   plan: Plan;
 }
 
 const props = defineProps<Props>();
+
+// 기본 별자리 정의
+const defaultConstellation = {
+  stars: [
+    { x: 30, y: 20, r: 2, brightness: 1, delay: 0 },
+    { x: 50, y: 30, r: 1.5, brightness: 0.9, delay: 0.3 },
+    { x: 70, y: 20, r: 2, brightness: 0.8, delay: 0.6 },
+    { x: 50, y: 50, r: 2.5, brightness: 1, delay: 0.9 },
+    { x: 30, y: 80, r: 1.5, brightness: 0.7, delay: 1.2 },
+    { x: 50, y: 70, r: 2, brightness: 0.85, delay: 1.5 },
+    { x: 70, y: 80, r: 1.5, brightness: 0.75, delay: 1.8 },
+  ],
+  connections: [
+    { from: 0, to: 1 },
+    { from: 1, to: 2 },
+    { from: 1, to: 3 },
+    { from: 3, to: 4 },
+    { from: 3, to: 5 },
+    { from: 3, to: 6 },
+    { from: 4, to: 5 },
+    { from: 5, to: 6 },
+  ],
+};
+
+// computed 속성을 사용하여 constellation이 없을 경우 기본값 제공
+const constellation = computed(() => props.plan.stella || defaultConstellation);
 const isHovered = ref(false);
 
 const emit = defineEmits<{
   cardClick: [plan: Plan];
   likeClick: [plan: Plan];
-  tagClick: [tag: string];
+  tagClick: [tag: Tag];
 }>();
 
 const backgroundStars = Array.from({ length: 30 }, () => ({
@@ -62,8 +88,8 @@ const handleTagClick = (index: number) => {
       <!-- 별자리 SVG -->
       <div class="absolute inset-0 transition-transform duration-500 group-hover:scale-105">
         <Constellation
-          :stars="plan.constellation.stars"
-          :connections="plan.constellation.connections"
+          :stars="constellation.stars"
+          :connections="constellation.connections"
           :backgroundStars="backgroundStars"
           :isHovered="isHovered"
         />
@@ -88,12 +114,12 @@ const handleTagClick = (index: number) => {
       <!-- 태그들과 좋아요 수 -->
       <div class="flex flex-col gap-1">
         <div class="flex flex-wrap gap-2">
-          <Tag
+          <TagComp
             v-for="tag in plan.tags.slice(0, 3)"
-            :key="tag"
-            :label="tag"
+            :key="tag.tagId"
+            :label="tag.name"
             @tagClick="handleTagClick"
-          ></Tag>
+          ></TagComp>
         </div>
         <div class="flex items-center gap-2 text-purple-200">
           <LikeButton transparent :isLiked="plan.isLiked" size="sm" @click.stop="handleLikeClick" />

--- a/front_end/src/components/views/main/TagOverviewSection.vue
+++ b/front_end/src/components/views/main/TagOverviewSection.vue
@@ -53,12 +53,11 @@ import TagCard from '@/components/TagCard/TagCard.vue';
 import { getPlans, getPopularTags, type Plan, type Tag } from '@/services/api/domains/plan';
 import { getAttractions, type Attraction } from '@/services/api/domains/attraction';
 
-// 데이터를 담을 ref 생성
 const healingPlans = ref<Plan[]>([]);
 const popularAttractions = ref<Attraction[]>([]);
 const popularTags = ref<Tag[]>([]);
 
-// 부모 컴포넌트에서 <Suspense>로 처리할 비동기 함수
+//TODO: 이후 Suspence 와 ErrorBoundary로 관리 예정
 const setupData = async () => {
   const [plansResponse, attractionsResponse, tagsResponse] = await Promise.all([
     getPlans({

--- a/front_end/src/components/views/main/TagOverviewSection.vue
+++ b/front_end/src/components/views/main/TagOverviewSection.vue
@@ -3,7 +3,7 @@
     <div class="container mx-auto">
       <GridCardListContainer title="인기 여행 태그">
         <TagCard
-          v-for="tag in sampleTags"
+          v-for="tag in popularTags"
           :key="tag.id"
           :label="tag.label"
           :labelCount="tag.count"
@@ -16,21 +16,6 @@
       >
         <PlanCard
           v-for="plan in healingPlans"
-          :key="plan.planId"
-          :plan="plan"
-          @cardClick="handlePlanCardClick"
-          @likeClick="handlePlanLikeClick"
-          @tagClick="handlePlanTagClick"
-        />
-      </RowCardListContainer>
-
-      <RowCardListContainer
-        title="유럽"
-        moreLink="/categories/europe"
-        @moreClick="() => handleMoreClick('유럽')"
-      >
-        <PlanCard
-          v-for="plan in europePlans"
           :key="plan.planId"
           :plan="plan"
           @cardClick="handlePlanCardClick"
@@ -54,22 +39,6 @@
           @tagClick="handleAttractionTagClick"
         />
       </RowCardListContainer>
-
-      <RowCardListContainer
-        title="서울 명소"
-        moreLink="/attractions/seoul"
-        @moreClick="() => handleMoreClick('서울 명소')"
-      >
-        <AttractionCard
-          v-for="attraction in seoulAttractions"
-          :key="attraction.attractionId"
-          :attraction="attraction"
-          :showRating="true"
-          @cardClick="handleAttractionCardClick"
-          @likeClick="handleAttractionLikeClick"
-          @tagClick="handleAttractionTagClick"
-        />
-      </RowCardListContainer>
     </div>
   </section>
 </template>
@@ -81,581 +50,61 @@ import PlanCard from '@/components/PlanCard/PlanCard.vue';
 import AttractionCard from '@/components/AttractionCard/AttractionCard.vue';
 import GridCardListContainer from '@/components/GridCardListContainer/GridCardListContainer.vue';
 import TagCard from '@/components/TagCard/TagCard.vue';
-import type { Plan, Attraction } from '@/types/type';
+import { getPlans, getPopularTags, type Plan } from '@/services/api/domains/plan';
+import { getAttractions, type Attraction } from '@/services/api/domains/attraction';
 
-const sampleTags = [
-  { id: '1', label: '힐링', count: 2543 },
-  { id: '2', label: '액티비티', count: 1872 },
-  { id: '3', label: '미식여행', count: 1654 },
-  { id: '4', label: '가족여행', count: 1432 },
-  { id: '5', label: '도시여행', count: 1221 },
-  { id: '6', label: '자연', count: 986 },
-  { id: '7', label: '휴양여행', count: 872 },
-  { id: '8', label: '커플여행', count: 754 },
-];
+// 데이터를 담을 ref 생성
+const healingPlans = ref<Plan[]>([]);
+const popularAttractions = ref<Attraction[]>([]);
+const popularTags = ref<Tag[]>([]);
 
-// 힐링 여행 계획 더미 데이터
-const healingPlans = ref<Plan[]>([
-  {
-    planId: 1,
-    title: '강원도 숲속 힐링 여행',
-    description: '강원도 깊은 숲속에서 몸과 마음을 치유하는 5일간의 여행',
-    startDate: '2025-06-10',
-    endDate: '2025-06-14',
-    tags: ['힐링', '자연', '숲', '강원도'],
-    planWriters: [{ userId: 1, name: '김힐링' }],
-    likeCount: 328,
-    isLiked: false,
-    constellation: {
-      stars: [
-        { x: 30, y: 20, r: 0.8, brightness: 0.7 },
-        { x: 50, y: 30, r: 0.6, brightness: 0.5 },
-        { x: 70, y: 20, r: 0.9, brightness: 0.8 },
-        { x: 40, y: 50, r: 0.7, brightness: 0.6 },
-        { x: 20, y: 40, r: 0.5, brightness: 0.4 },
-      ],
-      connections: [
-        { from: 0, to: 1 },
-        { from: 1, to: 2 },
-        { from: 2, to: 3 },
-        { from: 3, to: 4 },
-        { from: 4, to: 0 },
-      ],
-    },
-  },
-  {
-    planId: 2,
-    title: '제주 바다 명상 여행',
-    description: '제주 해안가에서 명상과 함께하는 힐링 휴양',
-    startDate: '2025-07-05',
-    endDate: '2025-07-08',
-    tags: ['힐링', '명상', '제주', '바다'],
-    planWriters: [{ userId: 2, name: '명상가이드' }],
-    likeCount: 245,
-    isLiked: true,
-    constellation: {
-      stars: [
-        { x: 30, y: 30, r: 0.8, brightness: 0.7 },
-        { x: 70, y: 30, r: 0.6, brightness: 0.5 },
-        { x: 50, y: 50, r: 0.9, brightness: 0.8 },
-        { x: 30, y: 70, r: 0.7, brightness: 0.6 },
-        { x: 70, y: 70, r: 0.5, brightness: 0.4 },
-      ],
-      connections: [
-        { from: 0, to: 1 },
-        { from: 1, to: 2 },
-        { from: 2, to: 3 },
-        { from: 3, to: 4 },
-        { from: 4, to: 0 },
-      ],
-    },
-  },
-  {
-    planId: 3,
-    title: '전남 템플스테이 체험',
-    description: '전남 산사에서 템플스테이를 통해 마음의 평화 찾기',
-    startDate: '2025-05-20',
-    endDate: '2025-05-23',
-    tags: ['힐링', '템플스테이', '명상', '전남'],
-    planWriters: [{ userId: 3, name: '절에사는사람' }],
-    likeCount: 187,
-    isLiked: false,
-    constellation: {
-      stars: [
-        { x: 20, y: 20, r: 0.8, brightness: 0.7 },
-        { x: 60, y: 20, r: 0.6, brightness: 0.5 },
-        { x: 80, y: 50, r: 0.9, brightness: 0.8 },
-        { x: 40, y: 60, r: 0.7, brightness: 0.6 },
-        { x: 20, y: 50, r: 0.5, brightness: 0.4 },
-      ],
-      connections: [
-        { from: 0, to: 1 },
-        { from: 1, to: 2 },
-        { from: 2, to: 3 },
-        { from: 3, to: 4 },
-        { from: 4, to: 0 },
-      ],
-    },
-  },
-  {
-    planId: 4,
-    title: '울릉도 청정 자연 여행',
-    description: '울릉도와 독도의 맑은 공기를 마시며 힐링하는 여행',
-    startDate: '2025-08-12',
-    endDate: '2025-08-16',
-    tags: ['힐링', '울릉도', '독도', '자연'],
-    planWriters: [{ userId: 4, name: '독도사랑' }],
-    likeCount: 203,
-    isLiked: false,
-    constellation: {
-      stars: [
-        { x: 40, y: 20, r: 0.8, brightness: 0.7 },
-        { x: 20, y: 40, r: 0.6, brightness: 0.5 },
-        { x: 40, y: 60, r: 0.9, brightness: 0.8 },
-        { x: 60, y: 40, r: 0.7, brightness: 0.6 },
-      ],
-      connections: [
-        { from: 0, to: 1 },
-        { from: 1, to: 2 },
-        { from: 2, to: 3 },
-        { from: 3, to: 0 },
-      ],
-    },
-  },
-]);
+// 부모 컴포넌트에서 <Suspense>로 처리할 비동기 함수
+const setupData = async () => {
+  const [plansResponse, attractionsResponse, tagsResponse] = await Promise.all([
+    getPlans({
+      page: 1,
+      size: 10,
+      sort: 'RECENT',
+    }),
+    getAttractions({
+      page: 1,
+      size: 10,
+    }),
+    getPopularTags(),
+  ]);
 
-// 유럽 여행 계획 더미 데이터
-const europePlans = ref<Plan[]>([
-  {
-    planId: 11,
-    title: '동유럽 8일 완전정복',
-    description: '체코, 오스트리아, 헝가리를 아우르는 동유럽 문화 탐방',
-    startDate: '2025-09-10',
-    endDate: '2025-09-17',
-    tags: ['유럽', '동유럽', '문화', '역사'],
-    planWriters: [{ userId: 8, name: '유럽탐험가' }],
-    likeCount: 356,
-    isLiked: false,
-    constellation: {
-      stars: [
-        { x: 20, y: 20, r: 0.8, brightness: 0.7 },
-        { x: 40, y: 40, r: 0.6, brightness: 0.5 },
-        { x: 60, y: 20, r: 0.9, brightness: 0.8 },
-        { x: 80, y: 40, r: 0.7, brightness: 0.6 },
-        { x: 50, y: 60, r: 0.5, brightness: 0.4 },
-        { x: 20, y: 60, r: 0.6, brightness: 0.5 },
-      ],
-      connections: [
-        { from: 0, to: 1 },
-        { from: 1, to: 2 },
-        { from: 2, to: 3 },
-        { from: 3, to: 4 },
-        { from: 4, to: 5 },
-        { from: 5, to: 0 },
-      ],
-    },
-  },
-  {
-    planId: 12,
-    title: '남부 이탈리아 로드트립',
-    description: '나폴리부터 시칠리아까지 남부 이탈리아를 자동차로 여행',
-    startDate: '2025-05-25',
-    endDate: '2025-06-05',
-    tags: ['유럽', '이탈리아', '로드트립', '미식'],
-    planWriters: [{ userId: 9, name: '피자러버' }],
-    likeCount: 284,
-    isLiked: true,
-    constellation: {
-      stars: [
-        { x: 30, y: 20, r: 0.8, brightness: 0.7 },
-        { x: 20, y: 40, r: 0.6, brightness: 0.5 },
-        { x: 40, y: 60, r: 0.9, brightness: 0.8 },
-        { x: 60, y: 60, r: 0.7, brightness: 0.6 },
-        { x: 80, y: 40, r: 0.5, brightness: 0.4 },
-        { x: 70, y: 20, r: 0.6, brightness: 0.5 },
-      ],
-      connections: [
-        { from: 0, to: 1 },
-        { from: 1, to: 2 },
-        { from: 2, to: 3 },
-        { from: 3, to: 4 },
-        { from: 4, to: 5 },
-        { from: 5, to: 0 },
-      ],
-    },
-  },
-  {
-    planId: 13,
-    title: '북유럽 오로라 여행',
-    description: '핀란드, 노르웨이에서 오로라를 감상하는 겨울 여행',
-    startDate: '2026-01-15',
-    endDate: '2026-01-22',
-    tags: ['유럽', '북유럽', '오로라', '겨울'],
-    planWriters: [{ userId: 10, name: '오로라헌터' }],
-    likeCount: 412,
-    isLiked: false,
-    constellation: {
-      stars: [
-        { x: 30, y: 30, r: 0.8, brightness: 0.7 },
-        { x: 50, y: 20, r: 0.6, brightness: 0.5 },
-        { x: 70, y: 30, r: 0.9, brightness: 0.8 },
-        { x: 60, y: 50, r: 0.7, brightness: 0.6 },
-        { x: 40, y: 60, r: 0.5, brightness: 0.4 },
-      ],
-      connections: [
-        { from: 0, to: 1 },
-        { from: 1, to: 2 },
-        { from: 2, to: 3 },
-        { from: 3, to: 4 },
-        { from: 4, to: 0 },
-      ],
-    },
-  },
-  {
-    planId: 14,
-    title: '스페인 바르셀로나 건축 투어',
-    description: '가우디의 작품을 중심으로 한 바르셀로나 건축 탐방',
-    startDate: '2025-08-05',
-    endDate: '2025-08-10',
-    tags: ['유럽', '스페인', '건축', '문화'],
-    planWriters: [{ userId: 11, name: '건축덕후' }],
-    likeCount: 276,
-    isLiked: true,
-    constellation: {
-      stars: [
-        { x: 40, y: 20, r: 0.8, brightness: 0.7 },
-        { x: 20, y: 40, r: 0.6, brightness: 0.5 },
-        { x: 40, y: 60, r: 0.9, brightness: 0.8 },
-        { x: 60, y: 40, r: 0.7, brightness: 0.6 },
-      ],
-      connections: [
-        { from: 0, to: 1 },
-        { from: 1, to: 2 },
-        { from: 2, to: 3 },
-        { from: 3, to: 0 },
-      ],
-    },
-  },
-  {
-    planId: 15,
-    title: '동유럽 8일 완전정복',
-    description: '체코, 오스트리아, 헝가리를 아우르는 동유럽 문화 탐방',
-    startDate: '2025-09-10',
-    endDate: '2025-09-17',
-    tags: ['유럽', '동유럽', '문화', '역사'],
-    planWriters: [{ userId: 8, name: '유럽탐험가' }],
-    likeCount: 356,
-    isLiked: false,
-    constellation: {
-      stars: [
-        { x: 20, y: 20, r: 0.8, brightness: 0.7 },
-        { x: 40, y: 40, r: 0.6, brightness: 0.5 },
-        { x: 60, y: 20, r: 0.9, brightness: 0.8 },
-        { x: 80, y: 40, r: 0.7, brightness: 0.6 },
-        { x: 50, y: 60, r: 0.5, brightness: 0.4 },
-        { x: 20, y: 60, r: 0.6, brightness: 0.5 },
-      ],
-      connections: [
-        { from: 0, to: 1 },
-        { from: 1, to: 2 },
-        { from: 2, to: 3 },
-        { from: 3, to: 4 },
-        { from: 4, to: 5 },
-        { from: 5, to: 0 },
-      ],
-    },
-  },
-  {
-    planId: 16,
-    title: '남부 이탈리아 로드트립',
-    description: '나폴리부터 시칠리아까지 남부 이탈리아를 자동차로 여행',
-    startDate: '2025-05-25',
-    endDate: '2025-06-05',
-    tags: ['유럽', '이탈리아', '로드트립', '미식'],
-    planWriters: [{ userId: 9, name: '피자러버' }],
-    likeCount: 284,
-    isLiked: true,
-    constellation: {
-      stars: [
-        { x: 30, y: 20, r: 0.8, brightness: 0.7 },
-        { x: 20, y: 40, r: 0.6, brightness: 0.5 },
-        { x: 40, y: 60, r: 0.9, brightness: 0.8 },
-        { x: 60, y: 60, r: 0.7, brightness: 0.6 },
-        { x: 80, y: 40, r: 0.5, brightness: 0.4 },
-        { x: 70, y: 20, r: 0.6, brightness: 0.5 },
-      ],
-      connections: [
-        { from: 0, to: 1 },
-        { from: 1, to: 2 },
-        { from: 2, to: 3 },
-        { from: 3, to: 4 },
-        { from: 4, to: 5 },
-        { from: 5, to: 0 },
-      ],
-    },
-  },
-  {
-    planId: 17,
-    title: '북유럽 오로라 여행',
-    description: '핀란드, 노르웨이에서 오로라를 감상하는 겨울 여행',
-    startDate: '2026-01-15',
-    endDate: '2026-01-22',
-    tags: ['유럽', '북유럽', '오로라', '겨울'],
-    planWriters: [{ userId: 10, name: '오로라헌터' }],
-    likeCount: 412,
-    isLiked: false,
-    constellation: {
-      stars: [
-        { x: 30, y: 30, r: 0.8, brightness: 0.7 },
-        { x: 50, y: 20, r: 0.6, brightness: 0.5 },
-        { x: 70, y: 30, r: 0.9, brightness: 0.8 },
-        { x: 60, y: 50, r: 0.7, brightness: 0.6 },
-        { x: 40, y: 60, r: 0.5, brightness: 0.4 },
-      ],
-      connections: [
-        { from: 0, to: 1 },
-        { from: 1, to: 2 },
-        { from: 2, to: 3 },
-        { from: 3, to: 4 },
-        { from: 4, to: 0 },
-      ],
-    },
-  },
-  {
-    planId: 18,
-    title: '스페인 바르셀로나 건축 투어',
-    description: '가우디의 작품을 중심으로 한 바르셀로나 건축 탐방',
-    startDate: '2025-08-05',
-    endDate: '2025-08-10',
-    tags: ['유럽', '스페인', '건축', '문화'],
-    planWriters: [{ userId: 11, name: '건축덕후' }],
-    likeCount: 276,
-    isLiked: true,
-    constellation: {
-      stars: [
-        { x: 40, y: 20, r: 0.8, brightness: 0.7 },
-        { x: 20, y: 40, r: 0.6, brightness: 0.5 },
-        { x: 40, y: 60, r: 0.9, brightness: 0.8 },
-        { x: 60, y: 40, r: 0.7, brightness: 0.6 },
-      ],
-      connections: [
-        { from: 0, to: 1 },
-        { from: 1, to: 2 },
-        { from: 2, to: 3 },
-        { from: 3, to: 0 },
-      ],
-    },
-  },
-]);
+  healingPlans.value = plansResponse.content;
+  popularAttractions.value = attractionsResponse.content;
+  popularTags.value = tagsResponse;
+};
 
-// 인기 관광지 더미 데이터
-const popularAttractions = ref<Attraction[]>([
-  {
-    attractionId: 1,
-    name: '경복궁',
-    image: 'https://example.com/gyeongbokgung.jpg',
-    address: '서울특별시 종로구 사직로 161',
-    contentType: '역사유적',
-    rating: 4.7,
-    latitude: 37.579617,
-    longitude: 126.977041,
-    isLiked: true,
-    likeCount: 542,
-  },
-  {
-    attractionId: 2,
-    name: '해운대 해수욕장',
-    image: 'https://example.com/haeundae.jpg',
-    address: '부산광역시 해운대구 해운대해변로 264',
-    contentType: '자연명소',
-    rating: 4.8,
-    latitude: 35.158795,
-    longitude: 129.160606,
-    isLiked: false,
-    likeCount: 487,
-  },
-  {
-    attractionId: 3,
-    name: '제주 성산일출봉',
-    image: 'https://example.com/seongsan.jpg',
-    address: '제주특별자치도 서귀포시 성산읍 성산리',
-    contentType: '자연명소',
-    rating: 4.9,
-    latitude: 33.458031,
-    longitude: 126.94252,
-    isLiked: true,
-    likeCount: 623,
-  },
-  {
-    attractionId: 4,
-    name: '남산서울타워',
-    image: 'https://example.com/seoultower.jpg',
-    address: '서울특별시 용산구 남산공원길 105',
-    contentType: '랜드마크',
-    rating: 4.5,
-    latitude: 37.551348,
-    longitude: 126.988266,
-    isLiked: false,
-    likeCount: 478,
-  },
-  {
-    attractionId: 5,
-    name: '전주 한옥마을',
-    image: 'https://example.com/hanok.jpg',
-    address: '전라북도 전주시 완산구 기린대로 99',
-    contentType: '문화명소',
-    rating: 4.6,
-    latitude: 35.815361,
-    longitude: 127.149882,
-    isLiked: false,
-    likeCount: 392,
-  },
-  {
-    attractionId: 1,
-    name: '경복궁',
-    image: 'https://example.com/gyeongbokgung.jpg',
-    address: '서울특별시 종로구 사직로 161',
-    contentType: '역사유적',
-    rating: 4.7,
-    latitude: 37.579617,
-    longitude: 126.977041,
-    isLiked: true,
-    likeCount: 542,
-  },
-  {
-    attractionId: 2,
-    name: '해운대 해수욕장',
-    image: 'https://example.com/haeundae.jpg',
-    address: '부산광역시 해운대구 해운대해변로 264',
-    contentType: '자연명소',
-    rating: 4.8,
-    latitude: 35.158795,
-    longitude: 129.160606,
-    isLiked: false,
-    likeCount: 487,
-  },
-  {
-    attractionId: 3,
-    name: '제주 성산일출봉',
-    image: 'https://example.com/seongsan.jpg',
-    address: '제주특별자치도 서귀포시 성산읍 성산리',
-    contentType: '자연명소',
-    rating: 4.9,
-    latitude: 33.458031,
-    longitude: 126.94252,
-    isLiked: true,
-    likeCount: 623,
-  },
-  {
-    attractionId: 4,
-    name: '남산서울타워',
-    image: 'https://example.com/seoultower.jpg',
-    address: '서울특별시 용산구 남산공원길 105',
-    contentType: '랜드마크',
-    rating: 4.5,
-    latitude: 37.551348,
-    longitude: 126.988266,
-    isLiked: false,
-    likeCount: 478,
-  },
-  {
-    attractionId: 5,
-    name: '전주 한옥마을',
-    image: 'https://example.com/hanok.jpg',
-    address: '전라북도 전주시 완산구 기린대로 99',
-    contentType: '문화명소',
-    rating: 4.6,
-    latitude: 35.815361,
-    longitude: 127.149882,
-    isLiked: false,
-    likeCount: 392,
-  },
-]);
+setupData();
 
-// 서울 명소 더미 데이터
-const seoulAttractions = ref<Attraction[]>([
-  {
-    attractionId: 6,
-    name: '광화문광장',
-    image: 'https://example.com/gwanghwamun.jpg',
-    address: '서울특별시 종로구 세종로',
-    contentType: '랜드마크',
-    rating: 4.3,
-    latitude: 37.575268,
-    longitude: 126.976896,
-    isLiked: true,
-    likeCount: 312,
-  },
-  {
-    attractionId: 7,
-    name: '명동',
-    image: 'https://example.com/myeongdong.jpg',
-    address: '서울특별시 중구 명동길',
-    contentType: '쇼핑',
-    rating: 4.2,
-    latitude: 37.564432,
-    longitude: 126.981119,
-    isLiked: false,
-    likeCount: 367,
-  },
-  {
-    attractionId: 8,
-    name: '북촌 한옥마을',
-    image: 'https://example.com/bukchon.jpg',
-    address: '서울특별시 종로구 계동길 37',
-    contentType: '문화명소',
-    rating: 4.6,
-    latitude: 37.58273,
-    longitude: 126.983771,
-    isLiked: true,
-    likeCount: 419,
-  },
-  {
-    attractionId: 9,
-    name: '동대문디자인플라자',
-    image: 'https://example.com/ddp.jpg',
-    address: '서울특별시 중구 을지로 281',
-    contentType: '문화시설',
-    rating: 4.4,
-    latitude: 37.566809,
-    longitude: 127.009391,
-    isLiked: false,
-    likeCount: 342,
-  },
-  {
-    attractionId: 10,
-    name: '홍대 거리',
-    image: 'https://example.com/hongdae.jpg',
-    address: '서울특별시 마포구 와우산로 29',
-    contentType: '문화거리',
-    rating: 4.5,
-    latitude: 37.55653,
-    longitude: 126.923952,
-    isLiked: true,
-    likeCount: 387,
-  },
-]);
-
-// 이벤트 핸들러
 const handlePlanCardClick = (plan: Plan) => {
   console.log('여행 계획 카드 클릭:', plan.title);
-  // 여행 계획 상세 페이지로 이동
-  // ex: router.push(`/plans/${plan.planId}`);
 };
 
 const handlePlanLikeClick = (plan: Plan) => {
   console.log('여행 계획 좋아요 클릭:', plan.title);
-  // 좋아요 상태 변경 로직
-  // ex: 좋아요 API 호출 후 상태 업데이트
 };
 
 const handlePlanTagClick = (tag: string) => {
   console.log('여행 계획 태그 클릭:', tag);
-  // 태그로 필터링 로직
-  // ex: router.push(`/tags/${encodeURIComponent(tag)}`);
 };
 
 const handleAttractionCardClick = (attraction: Attraction) => {
   console.log('관광지 카드 클릭:', attraction.name);
-  // 관광지 상세 페이지로 이동
-  // ex: router.push(`/attractions/${attraction.attractionId}`);
 };
 
 const handleAttractionLikeClick = (attraction: Attraction) => {
   console.log('관광지 좋아요 클릭:', attraction.name);
-  // 좋아요 상태 변경 로직
-  // ex: 좋아요 API 호출 후 상태 업데이트
 };
 
 const handleAttractionTagClick = (contentType: string) => {
   console.log('관광지 태그(컨텐츠 타입) 클릭:', contentType);
-  // 콘텐츠 타입으로 필터링 로직
-  // ex: router.push(`/attractions/types/${encodeURIComponent(contentType)}`);
 };
 
 const handleMoreClick = (category: string) => {
   console.log('더보기 클릭:', category);
-  // 해당 카테고리 전체 목록 페이지로 이동
-  // 카테고리에 따라 다른 경로로 라우팅
 };
 </script>

--- a/front_end/src/components/views/main/TagOverviewSection.vue
+++ b/front_end/src/components/views/main/TagOverviewSection.vue
@@ -4,8 +4,8 @@
       <GridCardListContainer title="인기 여행 태그">
         <TagCard
           v-for="tag in popularTags"
-          :key="tag.id"
-          :label="tag.label"
+          :key="tag.tagId"
+          :label="tag.name"
           :labelCount="tag.count"
         ></TagCard>
       </GridCardListContainer>
@@ -50,7 +50,7 @@ import PlanCard from '@/components/PlanCard/PlanCard.vue';
 import AttractionCard from '@/components/AttractionCard/AttractionCard.vue';
 import GridCardListContainer from '@/components/GridCardListContainer/GridCardListContainer.vue';
 import TagCard from '@/components/TagCard/TagCard.vue';
-import { getPlans, getPopularTags, type Plan } from '@/services/api/domains/plan';
+import { getPlans, getPopularTags, type Plan, type Tag } from '@/services/api/domains/plan';
 import { getAttractions, type Attraction } from '@/services/api/domains/attraction';
 
 // 데이터를 담을 ref 생성
@@ -88,7 +88,7 @@ const handlePlanLikeClick = (plan: Plan) => {
   console.log('여행 계획 좋아요 클릭:', plan.title);
 };
 
-const handlePlanTagClick = (tag: string) => {
+const handlePlanTagClick = (tag: Tag) => {
   console.log('여행 계획 태그 클릭:', tag);
 };
 

--- a/front_end/src/services/api/domains/attraction/index.ts
+++ b/front_end/src/services/api/domains/attraction/index.ts
@@ -1,0 +1,23 @@
+import { ATTRACTION } from '../../endpoint';
+import api from '../../api';
+import type { ApiResponse, PagenationResponse } from '../../types';
+import type { Attraction, AttractionsParams } from './types';
+
+/**
+ * query parameter를 바탕으로 여행지 리스트 조회
+ * @returns 여행지 리스트
+ */
+export const getAttractions = async (
+  params?: AttractionsParams
+): Promise<PagenationResponse<Attraction>> => {
+  const response = await api.get<ApiResponse<PagenationResponse<Attraction>>>(
+    ATTRACTION.ATTRACTIONS,
+    {
+      params,
+    }
+  );
+
+  return response.data.body;
+};
+
+export type * from './types';

--- a/front_end/src/services/api/domains/attraction/index.ts
+++ b/front_end/src/services/api/domains/attraction/index.ts
@@ -20,4 +20,4 @@ export const getAttractions = async (
   return response.data.body;
 };
 
-export type * from './types';
+export * from './types';

--- a/front_end/src/services/api/domains/attraction/types.ts
+++ b/front_end/src/services/api/domains/attraction/types.ts
@@ -1,0 +1,34 @@
+export type AttractionsParams = {
+  page?: number;
+  size?: number;
+  sidoCode?: number;
+  gugunCode?: number;
+  contentTypeId?: number;
+  keyword?: string;
+};
+
+export type Attraction = {
+  attractionId: number;
+  contentType: number;
+  name: string;
+  image: string;
+  address: string;
+  likeCount: number;
+  rating: number;
+  latitude: number;
+  longitude: number;
+  review: Review[];
+  isLiked: boolean;
+};
+
+export type Review = {
+  reviewId: number;
+  title: string;
+  content: string;
+  rating: number;
+  isLiked: boolean;
+  userId: number;
+  userName: string;
+  visitedDate: string;
+  createdAt: string;
+};

--- a/front_end/src/services/api/domains/auth/types.ts
+++ b/front_end/src/services/api/domains/auth/types.ts
@@ -1,4 +1,4 @@
-import type { AuthToken, User } from '../../types';
+import type { AuthToken, User } from '@/types/type';
 
 export type LoginRequest = {
   email: string;

--- a/front_end/src/services/api/domains/plan/index.ts
+++ b/front_end/src/services/api/domains/plan/index.ts
@@ -19,8 +19,8 @@ export const getPlans = async (params?: PlansParams): Promise<PagenationResponse
  * 인기 많은 여행 계획 태그 리스트 조회
  * @returns 여행 계획 태그 리스트
  */
-export const getPopularTags = async (): Promise<Tag[]> => {
-  const response = await api.get<ApiResponse<Tag[]>>(PLAN.TAGS);
+export const getPopularTags = async (size?: number): Promise<Tag[]> => {
+  const response = await api.get<ApiResponse<Tag[]>>(PLAN.TAGS, { params: { size } });
 
   return response.data.body;
 };

--- a/front_end/src/services/api/domains/plan/index.ts
+++ b/front_end/src/services/api/domains/plan/index.ts
@@ -1,0 +1,28 @@
+import { PLAN } from '../../endpoint';
+import api from '../../api';
+import type { ApiResponse, PagenationResponse } from '../../types';
+import type { Plan, PlansParams, Tag } from './types';
+
+/**
+ * query parameter를 바탕으로 여행 계획 리스트 조회
+ * @returns 여행 계획 리스트
+ */
+export const getPlans = async (params?: PlansParams): Promise<PagenationResponse<Plan>> => {
+  const response = await api.get<ApiResponse<PagenationResponse<Plan>>>(PLAN.PLANS, {
+    params,
+  });
+
+  return response.data.body;
+};
+
+/**
+ * 인기 많은 여행 계획 태그 리스트 조회
+ * @returns 여행 계획 태그 리스트
+ */
+export const getPopularTags = async (): Promise<Tag[]> => {
+  const response = await api.get<ApiResponse<Tag[]>>(PLAN.TAGS);
+
+  return response.data.body;
+};
+
+export type * from './types';

--- a/front_end/src/services/api/domains/plan/index.ts
+++ b/front_end/src/services/api/domains/plan/index.ts
@@ -25,4 +25,4 @@ export const getPopularTags = async (): Promise<Tag[]> => {
   return response.data.body;
 };
 
-export type * from './types';
+export * from './types';

--- a/front_end/src/services/api/domains/plan/types.ts
+++ b/front_end/src/services/api/domains/plan/types.ts
@@ -1,0 +1,33 @@
+export type PlansParams = {
+  page?: number;
+  size?: number;
+  search?: string;
+  userName?: string;
+  duration?: number;
+  sort?: 'RECENT' | 'POPULAR';
+};
+
+export type Plan = {
+  title: string;
+  description: string;
+  stella: null;
+  tags: Tag[];
+  planId: number;
+  isLiked: boolean;
+  startDate: string;
+  endDate: string;
+  likeCount: number;
+  isPublic: boolean;
+  planWriters: Writer[];
+};
+
+export type Tag = {
+  tagId: number;
+  name: string;
+  count: number;
+};
+
+export type Writer = {
+  userId: number;
+  name: string;
+};

--- a/front_end/src/services/api/endpoint.ts
+++ b/front_end/src/services/api/endpoint.ts
@@ -14,6 +14,6 @@ export const PLAN = {
 
 export const ATTRACTION = {
   ATTRACTIONS: 'v1/attractions',
-  DETAIL: (attractionId: number) => `v1/plans/${attractionId}`,
-  LIKE: (attractionId: number) => `v1/plans/${attractionId}/like`,
-};
+  DETAIL: (attractionId: number) => `v1/attractions/${attractionId}`,
+  LIKE: (attractionId: number) => `v1/attractions/${attractionId}/like`,
+} as const;

--- a/front_end/src/services/api/endpoint.ts
+++ b/front_end/src/services/api/endpoint.ts
@@ -4,3 +4,16 @@ export const AUTH = {
   SIGNUP: 'v1/user/signup',
   SIGNOUT: 'v1/user/signout',
 } as const;
+
+export const PLAN = {
+  PLANS: 'v1/plans',
+  TAGS: 'v1/plans/tags',
+  DETAIL: (planId: number) => `v1/plans/${planId}`,
+  LIKE: (planId: number) => `v1/plans/${planId}/like`,
+} as const;
+
+export const ATTRACTION = {
+  ATTRACTIONS: 'v1/attractions',
+  DETAIL: (attractionId: number) => `v1/plans/${attractionId}`,
+  LIKE: (attractionId: number) => `v1/plans/${attractionId}/like`,
+};

--- a/front_end/src/services/api/types.ts
+++ b/front_end/src/services/api/types.ts
@@ -10,13 +10,13 @@ export type ApiErrorBody = {
 
 export type ApiErrorResponse = ApiResponse<ApiErrorBody>;
 
-export type User = {
-  id: string;
-  email: string;
-  username: string;
-};
-
-export type AuthToken = {
-  accessToken: string;
-  refreshToken: string;
+export type PagenationResponse<T> = {
+  content: T[];
+  hasNext: boolean;
+  totalPages: number;
+  totalElements: number;
+  page: number;
+  size: number;
+  first: boolean;
+  last: boolean;
 };

--- a/front_end/src/stores/auth.ts
+++ b/front_end/src/stores/auth.ts
@@ -1,4 +1,4 @@
-import type { AuthToken, User } from '@/services/api';
+import type { AuthToken, User } from '@/types/type';
 import { defineStore } from 'pinia';
 
 interface AuthState {

--- a/front_end/src/types/type.ts
+++ b/front_end/src/types/type.ts
@@ -1,32 +1,12 @@
-export type Attraction = {
-  attractionId: number;
-  name: string;
-  image: string;
-  address: string;
-  contentType: string;
-  rating: number;
-  latitude: number;
-  longitude: number;
-  isLiked: boolean;
-  likeCount: number;
+export type User = {
+  id: string;
+  email: string;
+  username: string;
 };
 
-export type Plan = {
-  planId: number;
-  title: string;
-  description: string;
-  startDate: string;
-  endDate: string;
-  tags: string[];
-  planWriters: Writer[];
-  likeCount: number;
-  isLiked: boolean;
-  constellation: ConstellationData;
-};
-
-export type Writer = {
-  userId: number;
-  name: string;
+export type AuthToken = {
+  accessToken: string;
+  refreshToken: string;
 };
 
 export type Star = {


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #44 

## 📝 작업 내용
- [x] 인기순 태그 10개 조회
- [x] 여행 계획 목록 조회
- [x] 여행지 목록 조회

## 📑 작업 상세 내용
- 아직 여행지 contentType id-name 매핑 안함
- 별자리 데이터 Null
- 에러 처리, fallback 페이지 처리 추후 예정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 여행지와 여행 플랜 데이터를 백엔드 API에서 동적으로 불러오도록 변경되었습니다.
  - 여행지 및 여행 플랜 관련 API 서비스와 타입이 추가되었습니다.
  - 인기 태그 및 여행지 데이터를 실시간으로 조회하여 표시합니다.

- **버그 수정**
  - PlanCard에서 태그 클릭 시 태그 객체 전체를 이벤트로 전달하도록 개선되었습니다.
  - 오류 발생 시 콘솔에 에러 로그가 출력되도록 처리되었습니다.

- **리팩터**
  - 더미 데이터가 제거되고, 실제 API 호출을 통한 데이터 관리로 전환되었습니다.
  - 타입 구조가 도메인별로 분리 및 정비되었습니다.

- **스타일/기타**
  - 일부 타입 및 import 경로가 정리되었습니다.
  - API 엔드포인트 상수에 여행 플랜 및 여행지 관련 경로가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->