### PR TITLE
[BE-FEAT] 시군구 코드 조회 api추가 및 refresh 토큰 로직 수정

### DIFF
--- a/back_end/src/main/java/com/ssafy/stella_trip/attraction/controller/SigunguController.java
+++ b/back_end/src/main/java/com/ssafy/stella_trip/attraction/controller/SigunguController.java
@@ -1,0 +1,26 @@
+package com.ssafy.stella_trip.attraction.controller;
+
+
+import com.ssafy.stella_trip.attraction.dto.response.SigunguResponseDTO;
+import com.ssafy.stella_trip.attraction.service.SigunguService;
+import com.ssafy.stella_trip.common.response.CommonResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/attractions")
+@PreAuthorize("permitAll()")
+@RequiredArgsConstructor
+public class SigunguController {
+
+    private final SigunguService sigunguService;
+
+    @GetMapping("/sigungu")
+    public CommonResponse<SigunguResponseDTO> getSigungu() {
+        return new CommonResponse<>(sigunguService.getSigungu(), HttpStatus.OK);
+    }
+}

--- a/back_end/src/main/java/com/ssafy/stella_trip/attraction/controller/SigunguController.java
+++ b/back_end/src/main/java/com/ssafy/stella_trip/attraction/controller/SigunguController.java
@@ -4,6 +4,9 @@ package com.ssafy.stella_trip.attraction.controller;
 import com.ssafy.stella_trip.attraction.dto.response.SigunguResponseDTO;
 import com.ssafy.stella_trip.attraction.service.SigunguService;
 import com.ssafy.stella_trip.common.response.CommonResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -20,6 +23,13 @@ public class SigunguController {
     private final SigunguService sigunguService;
 
     @GetMapping("/sigungu")
+    @Operation(
+            summary = "시군구 정보 조회",
+            description = "시군구 정보 조회 api입니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "정상적으로 조회 완료"),
+    })
     public CommonResponse<SigunguResponseDTO> getSigungu() {
         return new CommonResponse<>(sigunguService.getSigungu(), HttpStatus.OK);
     }

--- a/back_end/src/main/java/com/ssafy/stella_trip/attraction/dto/SigunguDTO.java
+++ b/back_end/src/main/java/com/ssafy/stella_trip/attraction/dto/SigunguDTO.java
@@ -1,0 +1,15 @@
+package com.ssafy.stella_trip.attraction.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class SigunguDTO {
+    private int sidoCode;
+    private String sidoName;
+    private int gugunCode;
+    private String gugunName;
+}

--- a/back_end/src/main/java/com/ssafy/stella_trip/attraction/dto/response/GugunResponseDTO.java
+++ b/back_end/src/main/java/com/ssafy/stella_trip/attraction/dto/response/GugunResponseDTO.java
@@ -1,0 +1,14 @@
+package com.ssafy.stella_trip.attraction.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class GugunResponseDTO {
+    private int sidoCode;
+    private int gugunCode;
+    private String gugunName;
+}

--- a/back_end/src/main/java/com/ssafy/stella_trip/attraction/dto/response/SidoResponseDTO.java
+++ b/back_end/src/main/java/com/ssafy/stella_trip/attraction/dto/response/SidoResponseDTO.java
@@ -1,0 +1,16 @@
+package com.ssafy.stella_trip.attraction.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class SidoResponseDTO {
+    private int sidoCode;
+    private String sidoName;
+    private List<GugunResponseDTO> gugunList;
+}

--- a/back_end/src/main/java/com/ssafy/stella_trip/attraction/dto/response/SigunguResponseDTO.java
+++ b/back_end/src/main/java/com/ssafy/stella_trip/attraction/dto/response/SigunguResponseDTO.java
@@ -1,0 +1,14 @@
+package com.ssafy.stella_trip.attraction.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class SigunguResponseDTO {
+    List<SidoResponseDTO> sidoList;
+}

--- a/back_end/src/main/java/com/ssafy/stella_trip/attraction/service/SigunguService.java
+++ b/back_end/src/main/java/com/ssafy/stella_trip/attraction/service/SigunguService.java
@@ -40,9 +40,10 @@ public class SigunguService {
             SidoResponseDTO sidoResponseDTO = sidoMap.get(sigunguDTO.getSidoCode());
             sidoResponseDTO.getGugunList().add(new GugunResponseDTO(sigunguDTO.getSidoCode(), sigunguDTO.getGugunCode(), sigunguDTO.getGugunName()));
         });
-        redisTemplate.opsForValue().set("sigungu", sigunguList);
+        SigunguResponseDTO sigunguResponseDTO = new SigunguResponseDTO(new ArrayList<>(sidoMap.values()));
+        redisTemplate.opsForValue().set("sigungu", sigunguResponseDTO);
 
-        return new SigunguResponseDTO(new ArrayList<>(sidoMap.values()));
+        return sigunguResponseDTO;
     }
 
 }

--- a/back_end/src/main/java/com/ssafy/stella_trip/attraction/service/SigunguService.java
+++ b/back_end/src/main/java/com/ssafy/stella_trip/attraction/service/SigunguService.java
@@ -1,0 +1,48 @@
+package com.ssafy.stella_trip.attraction.service;
+
+
+import com.ssafy.stella_trip.attraction.dto.SigunguDTO;
+import com.ssafy.stella_trip.attraction.dto.response.GugunResponseDTO;
+import com.ssafy.stella_trip.attraction.dto.response.SidoResponseDTO;
+import com.ssafy.stella_trip.attraction.dto.response.SigunguResponseDTO;
+import com.ssafy.stella_trip.dao.sigungu.SigunguDAO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class SigunguService {
+
+    private final SigunguDAO sigunguDAO;
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public SigunguResponseDTO getSigungu() {
+
+        if (redisTemplate.hasKey("sigungu")) {
+            Object cachedValue = redisTemplate.opsForValue().get("sigungu");
+            if (cachedValue instanceof SigunguResponseDTO) {
+                return (SigunguResponseDTO) cachedValue;
+            }
+        }
+
+        List<SigunguDTO> sigunguList = sigunguDAO.getSigunguList();
+        Map<Integer, SidoResponseDTO> sidoMap = new HashMap<>();
+        sigunguList.forEach(sigunguDTO -> {
+            if(!sidoMap.containsKey(sigunguDTO.getSidoCode())){
+                sidoMap.put(sigunguDTO.getSidoCode(), new SidoResponseDTO(sigunguDTO.getSidoCode(), sigunguDTO.getSidoName(), new ArrayList<>()));
+            }
+            SidoResponseDTO sidoResponseDTO = sidoMap.get(sigunguDTO.getSidoCode());
+            sidoResponseDTO.getGugunList().add(new GugunResponseDTO(sigunguDTO.getSidoCode(), sigunguDTO.getGugunCode(), sigunguDTO.getGugunName()));
+        });
+        redisTemplate.opsForValue().set("sigungu", sigunguList);
+
+        return new SigunguResponseDTO(new ArrayList<>(sidoMap.values()));
+    }
+
+}

--- a/back_end/src/main/java/com/ssafy/stella_trip/dao/sigungu/SigunguDAO.java
+++ b/back_end/src/main/java/com/ssafy/stella_trip/dao/sigungu/SigunguDAO.java
@@ -1,0 +1,11 @@
+package com.ssafy.stella_trip.dao.sigungu;
+
+import com.ssafy.stella_trip.attraction.dto.SigunguDTO;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
+
+@Mapper
+public interface SigunguDAO {
+    List<SigunguDTO> getSigunguList();
+}

--- a/back_end/src/main/java/com/ssafy/stella_trip/security/util/JwtTokenProvider.java
+++ b/back_end/src/main/java/com/ssafy/stella_trip/security/util/JwtTokenProvider.java
@@ -4,27 +4,35 @@ import com.ssafy.stella_trip.user.dto.UserRole;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Date;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 @Component
 public class JwtTokenProvider {
+
+    private final RedisTemplate<String, Object> redisTemplate;
 
     private final String secret;
     private final int accessExpirationTime;
     private final int refreshExpirationTime;
     private final SecretKey key;
+    private static final String BLACKLIST_PREFIX = "token-blacklist:";
 
     public JwtTokenProvider(
             @Value("${jwt.secret}") String secret,
             @Value("${jwt.access-token.expiration}") int accessExpirationTime,
-            @Value("${jwt.refresh-token.expiration}") int refreshExpirationTime
+            @Value("${jwt.refresh-token.expiration}") int refreshExpirationTime,
+            RedisTemplate<String, Object> redisTemplate
     ) throws NoSuchAlgorithmException {
         this.secret = secret;
         this.accessExpirationTime = accessExpirationTime;
@@ -32,7 +40,9 @@ public class JwtTokenProvider {
         // 해싱으로 32바이트 고정
         MessageDigest digest = MessageDigest.getInstance("SHA-256");
         byte[] hashBytes = digest.digest(secret.getBytes(StandardCharsets.UTF_8));
-        this.key = Keys.hmacShaKeyFor(hashBytes);    }
+        this.key = Keys.hmacShaKeyFor(hashBytes);
+        this.redisTemplate = redisTemplate;
+    }
 
     private JwtParser getJwtParser() {
         return Jwts.parser()
@@ -99,16 +109,69 @@ public class JwtTokenProvider {
     }
 
     /**
+     * 토큰에서 만료 일자 가져오기
+     * @param token 토큰
+     * @return 만료 일자
+     */
+    public Date getExpirationDateFromToken(String token) {
+        return getJwtParser()
+                .parseSignedClaims(token)
+                .getPayload()
+                .getExpiration();
+    }
+
+    /**
      * session 유효 검증 (시간 및 parsing 가능한지)
      * @param token 토큰
      * @return 유효하면 true
      */
     public boolean validateToken(String token) {
-        try{
+        try {
+            // Redis에 블랙리스트로 등록된 토큰인지 확인
+            if (isTokenBlacklisted(token)) {
+                return false;
+            }
             getJwtParser().parseSignedClaims(token);
             return true;
-        } catch (JwtException e){
+        } catch (JwtException e) {
             return false;
+        }
+    }
+
+    /**
+     * 토큰이 블랙리스트에 등록되어 있는지 확인
+     * @param token 검증할 토큰
+     * @return 블랙리스트에 있으면 true
+     */
+    private boolean isTokenBlacklisted(String token) {
+        return redisTemplate.hasKey(BLACKLIST_PREFIX + token);
+    }
+
+    /**
+     * 토큰을 블랙리스트에 추가 (로그아웃 등에서 사용)
+     * @param token 블랙리스트에 추가할 토큰
+     */
+    public void addToBlacklist(String token) {
+        try {
+            if(!validateToken(token)){
+                return;
+            }
+
+            // 토큰의 남은 유효 시간 계산
+            Date expiration = getExpirationDateFromToken(token);
+            long ttl = expiration.getTime() - System.currentTimeMillis();
+
+            // 만료 시간이 양수일 경우에만 Redis에 저장
+            if (ttl > 0) {
+                redisTemplate.opsForValue().set(
+                        BLACKLIST_PREFIX + token,
+                        "blacklisted",
+                        ttl,
+                        TimeUnit.MILLISECONDS
+                );
+            }
+        } catch (JwtException e) {
+            // 이미 만료된 토큰이거나 유효하지 않은 토큰인 경우 무시
         }
     }
 }

--- a/back_end/src/main/java/com/ssafy/stella_trip/user/controller/UserController.java
+++ b/back_end/src/main/java/com/ssafy/stella_trip/user/controller/UserController.java
@@ -2,6 +2,7 @@ package com.ssafy.stella_trip.user.controller;
 
 import com.ssafy.stella_trip.common.response.CommonResponse;
 import com.ssafy.stella_trip.user.dto.request.LoginRequestDTO;
+import com.ssafy.stella_trip.user.dto.request.LogoutRequestDTO;
 import com.ssafy.stella_trip.user.dto.request.SignupRequestDTO;
 import com.ssafy.stella_trip.user.dto.request.TokenRefreshRequestDTO;
 import com.ssafy.stella_trip.user.dto.response.ActionResponseDTO;
@@ -75,7 +76,7 @@ public class UserController {
         return new CommonResponse<TokenRefreshResponseDTO>(userService.refreshToken(refreshToken), HttpStatus.CREATED);
     }
 
-    @GetMapping("/logout")
+    @PostMapping("/logout")
     @Operation(
             summary = "로그아웃 처리 API",
             description = ""
@@ -83,15 +84,9 @@ public class UserController {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "정상적으로 로그아웃됨. 메인 페이지로 redirection")
     })
-    public CommonResponse<?> logout(HttpServletResponse response) {
-        // access 토큰 쿠키 삭제
-        Cookie jwtCookie = new Cookie("Authorization", null);
-        jwtCookie.setMaxAge(0);
-        jwtCookie.setPath("/");
-        jwtCookie.setHttpOnly(true);
-        jwtCookie.setSecure(true);
-        response.addCookie(jwtCookie);
-        return CommonResponse.builder().status(HttpStatus.OK).build(); // 실제로는 아무 동작 안 함
+    public CommonResponse<ActionResponseDTO> logout(@RequestBody LogoutRequestDTO logoutRequestDTO) {
+
+        return new CommonResponse<>(userService.logout(logoutRequestDTO), HttpStatus.OK);
     }
 
     @PostMapping("/signout")

--- a/back_end/src/main/java/com/ssafy/stella_trip/user/dto/request/LogoutRequestDTO.java
+++ b/back_end/src/main/java/com/ssafy/stella_trip/user/dto/request/LogoutRequestDTO.java
@@ -1,0 +1,12 @@
+package com.ssafy.stella_trip.user.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class LogoutRequestDTO {
+    private String refreshToken;
+}

--- a/back_end/src/main/resources/mappers/Sigungu.xml
+++ b/back_end/src/main/resources/mappers/Sigungu.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.ssafy.stella_trip.dao.sigungu.SigunguDAO">
+    <resultMap id="SigunguResultMap" type="SigunguDTO">
+        <result property="sidoCode" column="sido_code"/>
+        <result property="sidoName" column="sido_name"/>
+        <result property="gugunCode" column="gugun_code"/>
+        <result property="gugunName" column="gugun_name"/>
+    </resultMap>
+
+    <!-- 시군구코드들 조회 -->
+    <select id="getSigunguList" resultMap="SigunguResultMap">
+        SELECT g.sido_code, s.sido_name, g.gugun_code, g.gugun_name FROM gugun g
+        LEFT JOIN sido s ON g.sido_code = s.sido_code;
+    </select>
+</mapper>


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- 

## 📝 작업 내용
- [ ] 시군구 코드 조회 api 추가
- [ ] refresh 토큰 blacklist 구현 추가

## 📑 작업 상세 내용
시군구 코드 조회시 redis의 캐시를 이용
refresh token이 만료되면 blacklist에 해당 허용기간동안 올라가도록 변경


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 시군구(행정구역) 정보를 조회할 수 있는 새로운 API 엔드포인트가 추가되었습니다.
    - 시도 및 구군 정보를 계층적으로 포함한 응답 구조가 제공됩니다.
    - 로그아웃 시 리프레시 토큰을 블랙리스트에 등록하여 토큰 무효화가 적용됩니다.
    - 토큰 블랙리스트 기능이 추가되어, 만료 전 토큰도 서버에서 즉시 무효화할 수 있습니다.

- **버그 수정**
    - 로그아웃 방식이 GET에서 POST로 변경되어 보다 안전하게 처리됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->