### PR TITLE
[FE-FEAT] 여행 계획 탐색 페이지 레이아웃 및 기본 api 연결

### DIFF
--- a/front_end/src/components/NavigationBar/NavigationBar.vue
+++ b/front_end/src/components/NavigationBar/NavigationBar.vue
@@ -51,7 +51,7 @@ const isLoggedIn = computed(() => {
 // Navigation items - separate regular and auth items
 const menuItems = computed(() => {
   const navigationItems = [
-    { name: '여행계획', icon: Map, route: '/trip-plans' },
+    { name: '여행계획', icon: Map, route: '/plans' },
     { name: '여행지', icon: Compass, route: '/attractions' },
   ];
 

--- a/front_end/src/components/ui/button/index.ts
+++ b/front_end/src/components/ui/button/index.ts
@@ -1,22 +1,19 @@
-import { cva, type VariantProps } from 'class-variance-authority'
+import { cva, type VariantProps } from 'class-variance-authority';
 
-export { default as Button } from './Button.vue'
+export { default as Button } from './Button.vue';
 
 export const buttonVariants = cva(
-  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*=\'size-\'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive hover:cursor-pointer",
   {
     variants: {
       variant: {
-        default:
-          'bg-primary text-primary-foreground shadow-xs hover:bg-primary/90',
+        default: 'bg-primary text-primary-foreground shadow-xs hover:bg-primary/90',
         destructive:
           'bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60',
         outline:
           'border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50',
-        secondary:
-          'bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80',
-        ghost:
-          'hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50',
+        secondary: 'bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80',
+        ghost: 'hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50',
         link: 'text-primary underline-offset-4 hover:underline',
       },
       size: {
@@ -30,7 +27,7 @@ export const buttonVariants = cva(
       variant: 'default',
       size: 'default',
     },
-  },
-)
+  }
+);
 
-export type ButtonVariants = VariantProps<typeof buttonVariants>
+export type ButtonVariants = VariantProps<typeof buttonVariants>;

--- a/front_end/src/components/views/attraction/FilteredAttractions/FilteredAttractions.vue
+++ b/front_end/src/components/views/attraction/FilteredAttractions/FilteredAttractions.vue
@@ -17,7 +17,6 @@ const emit = defineEmits<{
   (e: 'cardClick', attraction: Attraction): void;
   (e: 'likeClick', attraction: Attraction): void;
   (e: 'tagClick', contentType: number): void;
-  (e: 'moreClick'): void;
 }>();
 
 const attractions = ref<Attraction[]>([]);

--- a/front_end/src/components/views/attraction/FilteredAttractions/index.ts
+++ b/front_end/src/components/views/attraction/FilteredAttractions/index.ts
@@ -1,2 +1,3 @@
 export { default as FilteredAttractions } from './FilteredAttractions.vue';
 export { default as FilteredAttractionsSkeleton } from './FilteredAttractionsSkeleton.vue';
+export { default as FilteredAttractionsError } from './FilteredAttractionsError.vue';

--- a/front_end/src/components/views/plan/FilteredPlans/FilteredPlans.vue
+++ b/front_end/src/components/views/plan/FilteredPlans/FilteredPlans.vue
@@ -1,0 +1,67 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue';
+import PlanCard from '@/components/card/PlanCard/PlanCard.vue';
+import GridCardListContainer from '@/components/common/GridCardListContainer/GridCardListContainer.vue';
+import { getPlans, type PlansParams, type Plan, type Tag } from '@/services/api/domains/plan';
+
+interface Props {
+  apiParams?: PlansParams;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  apiParams: () => ({ page: 1, size: 10 }),
+});
+
+const emit = defineEmits<{
+  (e: 'cardClick', plan: Plan): void;
+  (e: 'likeClick', plan: Plan): void;
+  (e: 'tagClick', tag: Tag): void;
+}>();
+
+const plans = ref<Plan[]>([]);
+
+const fetchPlans = async () => {
+  const response = await getPlans(props.apiParams);
+  plans.value = response.content;
+};
+
+await fetchPlans();
+
+watch(
+  () => props.apiParams,
+  () => fetchPlans(),
+  { deep: true }
+);
+
+const handleCardClick = (plan: Plan) => {
+  emit('cardClick', plan);
+};
+
+const handleLikeClick = (plan: Plan) => {
+  emit('likeClick', plan);
+};
+
+const handleTagClick = (tag: Tag) => {
+  emit('tagClick', tag);
+};
+</script>
+
+<template>
+  <template v-if="plans.length === 0">
+    <div class="h-full w-full pt-16 text-center">
+      <p class="text-lg text-gray-200">검색 결과가 없습니다.</p>
+    </div>
+  </template>
+  <template v-else>
+    <GridCardListContainer :showTitle="false">
+      <PlanCard
+        v-for="plan in plans"
+        :key="plan.planId"
+        :plan="plan"
+        @cardClick="handleCardClick"
+        @likeClick="handleLikeClick"
+        @tagClick="handleTagClick"
+      />
+    </GridCardListContainer>
+  </template>
+</template>

--- a/front_end/src/components/views/plan/FilteredPlans/FilteredPlansError.vue
+++ b/front_end/src/components/views/plan/FilteredPlans/FilteredPlansError.vue
@@ -1,0 +1,14 @@
+<template>
+  <ErrorContent
+    :error="error"
+    :resetError="resetError"
+    :showRetry="true"
+    :description="description || '여행 계획 목록을 불러오는 중 문제가 발생했습니다'"
+  />
+</template>
+
+<script setup lang="ts">
+import ErrorContent, { type ErrorProps } from '@/components/common/ErrorContent/ErrorContent.vue';
+
+defineProps<ErrorProps>();
+</script>

--- a/front_end/src/components/views/plan/FilteredPlans/FilteredPlansSkeleton.vue
+++ b/front_end/src/components/views/plan/FilteredPlans/FilteredPlansSkeleton.vue
@@ -1,0 +1,10 @@
+<template>
+  <GridCardListContainer>
+    <CardSkeleton v-for="i in 10" :key="i" />
+  </GridCardListContainer>
+</template>
+
+<script setup lang="ts">
+import GridCardListContainer from '@/components/common/GridCardListContainer/GridCardListContainer.vue';
+import CardSkeleton from '@/components/skeleton/CardSkeleton/CardSkeleton.vue';
+</script>

--- a/front_end/src/components/views/plan/FilteredPlans/index.ts
+++ b/front_end/src/components/views/plan/FilteredPlans/index.ts
@@ -1,0 +1,3 @@
+export { default as FilteredPlans } from './FilteredPlans.vue';
+export { default as FilteredPlansSkeleton } from './FilteredPlansSkeleton.vue';
+export { default as FilteredPlansError } from './FilteredPlansError.vue';

--- a/front_end/src/components/views/plan/PlanDetail/AttractionItem.vue
+++ b/front_end/src/components/views/plan/PlanDetail/AttractionItem.vue
@@ -1,0 +1,46 @@
+<template>
+  <div class="flex gap-3 rounded-lg p-2 transition-colors hover:bg-white/5">
+    <div
+      class="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-purple-900/50 text-purple-200"
+    >
+      {{ order }}
+    </div>
+
+    <div class="flex-1">
+      <div class="mb-1 flex items-center justify-between">
+        <h5 class="font-medium text-white">{{ name }}</h5>
+        <span class="text-sm text-purple-300">
+          {{ formattedTime }}
+        </span>
+      </div>
+
+      <div class="flex items-start gap-1 text-xs text-gray-400">
+        <MapPin class="mt-0.5 h-3 w-3 flex-shrink-0 text-purple-400" />
+        <span class="line-clamp-1">{{ address }}</span>
+      </div>
+
+      <div v-if="memo" class="mt-1 text-sm text-gray-300">
+        <span class="line-clamp-2">{{ memo }}</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { MapPin } from 'lucide-vue-next';
+
+const props = defineProps<{
+  order: number;
+  name: string;
+  visitTime?: string;
+  address: string;
+  memo?: string;
+}>();
+
+const formattedTime = computed(() => {
+  if (!props.visitTime) return '';
+  const [hours, minutes] = props.visitTime.split(':');
+  return `${hours}:${minutes}`;
+});
+</script>

--- a/front_end/src/components/views/plan/PlanDetail/DailySchedule.vue
+++ b/front_end/src/components/views/plan/PlanDetail/DailySchedule.vue
@@ -1,0 +1,52 @@
+<template>
+  <Card
+    class="cursor-pointer border-white/10 bg-white/5 shadow-none transition-all duration-200 hover:bg-white/10"
+    @click="showRouteOnMap"
+  >
+    <CardHeader class="border-b border-white/10 p-3 pb-2">
+      <h4 class="flex items-center text-lg font-semibold text-white">
+        <Calendar class="mr-2 h-5 w-5 text-purple-400" />
+        {{ date }}
+      </h4>
+    </CardHeader>
+    <CardContent class="p-3">
+      <div class="space-y-3">
+        <AttractionItem
+          v-for="attraction in sortedAttractions"
+          :key="attraction.routeId"
+          :order="attraction.order"
+          :name="attraction.name"
+          :visitTime="attraction.visitTime"
+          :address="attraction.address"
+          :memo="attraction.memo ?? ''"
+        />
+      </div>
+    </CardContent>
+  </Card>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { Calendar } from 'lucide-vue-next';
+import { Card, CardHeader, CardContent } from '@/components/ui/card';
+import AttractionItem from './AttractionItem.vue';
+import type { RouteAttraction } from '@/services/api/domains/plan';
+
+const props = defineProps<{
+  date: string;
+  attractions: RouteAttraction[];
+}>();
+
+const emit = defineEmits<{
+  (e: 'showRoute', date: string, attractions: RouteAttraction[]): void;
+}>();
+
+const sortedAttractions = computed(() => {
+  if (!props.attractions || !Array.isArray(props.attractions)) return [];
+  return [...props.attractions].sort((a, b) => a.order - b.order);
+});
+
+const showRouteOnMap = () => {
+  emit('showRoute', props.date, props.attractions);
+};
+</script>

--- a/front_end/src/components/views/plan/PlanDetail/EmptySchedule.vue
+++ b/front_end/src/components/views/plan/PlanDetail/EmptySchedule.vue
@@ -1,0 +1,14 @@
+<template>
+  <div
+    class="flex h-32 flex-col items-center justify-center gap-2 rounded-lg border border-dashed border-white/20 p-4 text-center"
+  >
+    <ClipboardList class="h-8 w-8 text-purple-400/40" />
+    <div class="text-sm text-gray-400">
+      <p>아직 일정이 없습니다</p>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ClipboardList } from 'lucide-vue-next';
+</script>

--- a/front_end/src/components/views/plan/PlanDetail/PlanDetail.vue
+++ b/front_end/src/components/views/plan/PlanDetail/PlanDetail.vue
@@ -52,7 +52,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onUnmounted } from 'vue';
+import { ref, onUnmounted, watch } from 'vue';
 import { X } from 'lucide-vue-next';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -74,7 +74,7 @@ const emit = defineEmits<{
 }>();
 
 // 상태 관리 - 단일 참조 방식으로 변경
-const { selectPlanDetail, showRoute, clearPolylines } = useMapState();
+const { selectPlanDetail, showRoute, clearPolylines, clearMarkers } = useMapState();
 const planDetail = ref<PlanDetail | null>(null);
 const selectedDate = ref<string | null>(null);
 
@@ -167,6 +167,7 @@ const initializeData = async () => {
 
 onUnmounted(() => {
   clearPolylines();
+  clearMarkers();
 });
 
 await initializeData();

--- a/front_end/src/components/views/plan/PlanDetail/PlanDetail.vue
+++ b/front_end/src/components/views/plan/PlanDetail/PlanDetail.vue
@@ -1,0 +1,239 @@
+<template>
+  <div class="flex flex-col divide-y divide-white/10">
+    <!-- 별자리 표시 섹션 -->
+    <div class="relative h-40 w-full bg-indigo-950">
+      <!-- 별자리가 있으면 표시, 없으면 기본 배경 -->
+      <div v-if="planDetail?.stella" class="h-full w-full">
+        <Constellation
+          :stars="planDetail.stella.stars"
+          :connections="planDetail.stella.connections"
+          :backgroundStars="generateBackgroundStars()"
+          :isHovered="false"
+        />
+      </div>
+      <div
+        v-else
+        class="absolute inset-0 bg-gradient-to-br from-slate-900 via-purple-950 to-indigo-950 opacity-70"
+      ></div>
+      <div
+        class="absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent"
+      ></div>
+
+      <!-- 좋아요 버튼 -->
+      <button
+        class="absolute top-2 right-2 rounded-full bg-white/20 p-1.5 text-white shadow-sm transition-all duration-300 hover:bg-white/30"
+        :aria-label="planDetail?.isLiked ? '좋아요 취소하기' : '좋아요 추가하기'"
+        :aria-pressed="planDetail?.isLiked ? 'true' : 'false'"
+        @click="toggleLike"
+      >
+        <Heart v-if="planDetail?.isLiked" class="h-5 w-5 fill-purple-400 text-purple-400" />
+        <Heart v-else class="h-5 w-5 text-gray-300" />
+      </button>
+    </div>
+
+    <!-- 기본 정보 섹션 -->
+    <div class="space-y-3 bg-slate-900/30 p-3">
+      <div class="flex items-center justify-between">
+        <div class="flex flex-wrap gap-2">
+          <Badge
+            v-for="tag in planDetail?.tags"
+            :key="tag.tagId"
+            variant="outline"
+            class="rounded-md border-purple-400/50 bg-purple-900/20 text-purple-200"
+          >
+            {{ tag.name || `태그 ${tag.tagId}` }}
+          </Badge>
+        </div>
+        <div class="flex items-center">
+          <Heart class="h-4 w-4 fill-purple-400 text-purple-400" />
+          <span class="ml-1 text-sm font-medium text-purple-200">
+            {{ planDetail?.likeCount || 0 }}
+          </span>
+        </div>
+      </div>
+
+      <h2 class="text-xl font-bold text-white">{{ planDetail?.title }}</h2>
+
+      <div class="flex items-start gap-2 text-sm text-gray-300">
+        <Calendar class="mt-0.5 h-4 w-4 flex-shrink-0 text-purple-400" />
+        <span>{{ formatDateRange(planDetail?.startDate, planDetail?.endDate) }}</span>
+      </div>
+
+      <div v-if="planDetail?.description" class="mt-2 text-sm text-gray-300">
+        {{ planDetail.description }}
+      </div>
+
+      <div class="flex items-start gap-2 text-sm text-gray-300">
+        <Users class="mt-0.5 h-4 w-4 flex-shrink-0 text-purple-400" />
+        <div class="flex flex-wrap gap-1">
+          <span
+            v-for="writer in planDetail?.planWriters"
+            :key="writer.userId"
+            class="inline-block rounded-full bg-purple-900/30 px-2 py-0.5"
+          >
+            {{ writer.name }}
+          </span>
+        </div>
+      </div>
+    </div>
+
+    <!-- 일정 섹션 -->
+    <div class="flex-1 bg-slate-900/20 p-3">
+      <div class="mb-3">
+        <h3 class="font-semibold text-purple-200">일정</h3>
+      </div>
+
+      <!-- 일별 일정 목록 -->
+      <div v-if="planDetail?.details" class="space-y-4">
+        <div
+          v-for="(attractions, date) in planDetail.details"
+          :key="date"
+          class="rounded-lg border border-white/10 bg-white/5 p-3"
+        >
+          <h4
+            class="mb-2 flex items-center border-b border-white/10 pb-2 text-lg font-semibold text-white"
+          >
+            <Calendar class="mr-2 h-5 w-5 text-purple-400" />
+            {{ date }}
+          </h4>
+
+          <!-- 해당 날짜의 일정 -->
+          <div class="space-y-3">
+            <div
+              v-for="attraction in sortAttractionsByOrder(attractions)"
+              :key="attraction.routeId"
+              class="flex gap-3 rounded-lg p-2 transition-colors hover:bg-white/5"
+            >
+              <div
+                class="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-purple-900/50 text-purple-200"
+              >
+                {{ attraction.order }}
+              </div>
+
+              <div class="flex-1">
+                <div class="mb-1 flex items-center justify-between">
+                  <h5 class="font-medium text-white">{{ attraction.name }}</h5>
+                  <span class="text-sm text-purple-300">
+                    {{ formatTime(attraction.visitTime) }}
+                  </span>
+                </div>
+
+                <div class="flex items-start gap-1 text-xs text-gray-400">
+                  <MapPin class="mt-0.5 h-3 w-3 flex-shrink-0 text-purple-400" />
+                  <span class="line-clamp-1">{{ attraction.address }}</span>
+                </div>
+
+                <div v-if="attraction.memo" class="mt-1 text-sm text-gray-300">
+                  <span class="line-clamp-2">{{ attraction.memo }}</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- 일정이 없을 경우 -->
+      <div
+        v-else
+        class="flex h-32 flex-col items-center justify-center gap-2 rounded-lg border border-dashed border-white/20 p-4 text-center"
+      >
+        <ClipboardList class="h-8 w-8 text-purple-400/40" />
+        <div class="text-sm text-gray-400">
+          <p>아직 일정이 없습니다</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import { Heart, Calendar, MapPin, Users, ClipboardList } from 'lucide-vue-next';
+import { Badge } from '@/components/ui/badge';
+import Constellation from '@/components/common/Constellation/Constellation.vue';
+import { getPlanDetail, type PlanDetail, type RouteAttraction } from '@/services/api/domains/plan';
+import { useMapState } from '@/composables/useMapState';
+
+// Props
+const props = defineProps<{
+  planId: string;
+}>();
+
+// Emits
+const emit = defineEmits<{
+  (e: 'toggleLike', planId: number): void;
+}>();
+
+// 상태 관리 - 단일 참조 방식으로 변경
+const { selectPlanDetail } = useMapState();
+const planDetail = ref<PlanDetail | null>(null);
+
+// 날짜 범위 표시 형식
+const formatDateRange = (startDate?: string, endDate?: string) => {
+  if (!startDate || !endDate) return '';
+
+  const start = new Date(startDate);
+  const end = new Date(endDate);
+
+  const startStr = `${start.getFullYear()}년 ${start.getMonth() + 1}월 ${start.getDate()}일`;
+  const endStr = `${end.getFullYear()}년 ${end.getMonth() + 1}월 ${end.getDate()}일`;
+
+  return `${startStr} ~ ${endStr}`;
+};
+
+// 시간 포맷팅
+const formatTime = (timeStr: string) => {
+  if (!timeStr) return '';
+
+  const [hours, minutes] = timeStr.split(':');
+  return `${hours}:${minutes}`;
+};
+
+// 여행지 순서별 정렬
+const sortAttractionsByOrder = (attractions: RouteAttraction[]) => {
+  if (!attractions || !Array.isArray(attractions)) return [];
+  return [...attractions].sort((a, b) => a.order - b.order);
+};
+
+// 좋아요 토글
+const toggleLike = () => {
+  if (planDetail.value) {
+    emit('toggleLike', planDetail.value.planId);
+  }
+};
+
+// 배경 별 생성
+const generateBackgroundStars = () => {
+  return Array.from({ length: 30 }, () => ({
+    x: Math.random() * 100,
+    y: Math.random() * 100,
+    r: Math.random() * 0.8 + 0.2,
+    brightness: Math.random() * 0.4 + 0.2,
+    duration: Math.random() * 2 + 2,
+  }));
+};
+
+// 비동기 초기화 데이터 로드
+const initializeData = async () => {
+  // planId가 유효한지 확인
+  const planId = Number(props.planId);
+
+  if (isNaN(planId)) {
+    throw new Error('유효하지 않은 계획 ID');
+  }
+
+  // 계획 상세 정보 로드
+  const data = await getPlanDetail(planId);
+  planDetail.value = data;
+
+  // 이제 selectPlanDetail 호출 - 맵 관련 작업 수행
+  if (data) {
+    selectPlanDetail(data);
+  }
+
+  return data;
+};
+
+// AsyncContainer와 Suspense와 함께 사용하기 위해 setup에서 직접 호출
+await initializeData();
+</script>

--- a/front_end/src/components/views/plan/PlanDetail/PlanDetail.vue
+++ b/front_end/src/components/views/plan/PlanDetail/PlanDetail.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="flex flex-col divide-y divide-white/10">
     <!-- 별자리 표시 섹션 -->
-    <StellaHeader :stella="planDetail?.stella" :backgroundStars="generateBackgroundStars()" />
+    <StellaHeader :stella="planDetail?.stella" :backgroundStars="backgroundStars" />
 
     <!-- 기본 정보 섹션 -->
     <PlanInfo
@@ -99,15 +99,13 @@ const toggleLike = () => {
 };
 
 // 배경 별 생성
-const generateBackgroundStars = () => {
-  return Array.from({ length: 30 }, () => ({
-    x: Math.random() * 100,
-    y: Math.random() * 100,
-    r: Math.random() * 0.8 + 0.2,
-    brightness: Math.random() * 0.4 + 0.2,
-    duration: Math.random() * 2 + 2,
-  }));
-};
+const backgroundStars = Array.from({ length: 30 }, () => ({
+  x: Math.random() * 100,
+  y: Math.random() * 100,
+  r: Math.random() * 0.8 + 0.2,
+  brightness: Math.random() * 0.4 + 0.2,
+  duration: Math.random() * 2 + 2,
+}));
 
 // 일별 경로 지도에 표시
 const showRouteOnMap = (date: string, attractions: RouteAttraction[]) => {

--- a/front_end/src/components/views/plan/PlanDetail/PlanDetail.vue
+++ b/front_end/src/components/views/plan/PlanDetail/PlanDetail.vue
@@ -156,18 +156,10 @@ const resetRoute = () => {
 
 // 비동기 초기화 데이터 로드
 const initializeData = async () => {
-  // planId가 유효한지 확인
-  const planId = Number(props.planId);
-
-  if (isNaN(planId)) {
-    throw new Error('유효하지 않은 계획 ID');
-  }
-
-  // 계획 상세 정보 로드
-  const data = await getPlanDetail(planId);
+  const data = await getPlanDetail(props.planId);
   planDetail.value = data;
 
-  // 이제 selectPlanDetail 호출 - 맵 관련 작업 수행
+  // selectPlanDetail 호출
   if (data) {
     selectPlanDetail(data);
   }
@@ -179,6 +171,14 @@ onUnmounted(() => {
   clearPolylines();
 });
 
-// AsyncContainer와 Suspense와 함께 사용하기 위해 setup에서 직접 호출
 await initializeData();
+
+watch(
+  () => props.planId,
+  async (newId, oldId) => {
+    if (newId !== oldId) {
+      await initializeData();
+    }
+  }
+);
 </script>

--- a/front_end/src/components/views/plan/PlanDetail/PlanDetailError.vue
+++ b/front_end/src/components/views/plan/PlanDetail/PlanDetailError.vue
@@ -1,0 +1,19 @@
+<template>
+  <ErrorContent
+    :error="error"
+    :resetError="resetError"
+    :showRetry="true"
+    :title="title"
+    :description="description || `${planName}의 정보를 불러오는 중 문제가 발생했습니다`"
+  />
+</template>
+
+<script setup lang="ts">
+import ErrorContent, { type ErrorProps } from '@/components/common/ErrorContent/ErrorContent.vue';
+
+interface AttractionDetailErrorProps extends ErrorProps {
+  planName: string;
+}
+
+defineProps<AttractionDetailErrorProps>();
+</script>

--- a/front_end/src/components/views/plan/PlanDetail/PlanDetailSkeleton.vue
+++ b/front_end/src/components/views/plan/PlanDetail/PlanDetailSkeleton.vue
@@ -1,0 +1,82 @@
+<template>
+  <div class="flex flex-col divide-y divide-white/10">
+    <!-- 별자리 표시 섹션 스켈레톤 -->
+    <div class="relative h-40 w-full animate-pulse bg-indigo-950/30"></div>
+
+    <!-- 기본 정보 섹션 스켈레톤 -->
+    <div class="space-y-3 bg-slate-900/30 p-3">
+      <!-- 태그 및 좋아요 -->
+      <div class="flex justify-between">
+        <div class="flex gap-2">
+          <div class="h-6 w-16 animate-pulse rounded-md bg-purple-900/20"></div>
+          <div class="h-6 w-16 animate-pulse rounded-md bg-purple-900/20"></div>
+        </div>
+        <div class="h-6 w-10 animate-pulse rounded-md bg-purple-900/20"></div>
+      </div>
+
+      <!-- 제목 -->
+      <div class="h-7 w-3/4 animate-pulse rounded-md bg-white/10"></div>
+
+      <!-- 날짜 -->
+      <div class="flex items-center gap-2">
+        <div class="h-4 w-4 animate-pulse rounded-full bg-purple-900/30"></div>
+        <div class="h-5 w-1/2 animate-pulse rounded-md bg-white/10"></div>
+      </div>
+
+      <!-- 작성자 -->
+      <div class="flex items-center gap-2">
+        <div class="h-4 w-4 animate-pulse rounded-full bg-purple-900/30"></div>
+        <div class="h-5 w-1/3 animate-pulse rounded-md bg-white/10"></div>
+      </div>
+    </div>
+
+    <!-- 일정 섹션 스켈레톤 -->
+    <div class="bg-slate-900/20 p-3">
+      <!-- 섹션 제목 -->
+      <div class="mb-3 h-5 w-16 animate-pulse rounded-md bg-white/10"></div>
+
+      <!-- 간소화된 일정 스켈레톤 -->
+      <div class="space-y-4">
+        <!-- 첫 번째 날짜 -->
+        <div class="rounded-lg border border-white/10 bg-white/5 p-3">
+          <div class="mb-3 flex items-center border-b border-white/10 pb-2">
+            <div class="h-5 w-1/4 animate-pulse rounded-md bg-white/10"></div>
+          </div>
+
+          <!-- 일정 아이템들 -->
+          <div class="space-y-3">
+            <div v-for="i in 3" :key="i" class="flex gap-3 rounded-lg p-2">
+              <div class="h-8 w-8 animate-pulse rounded-full bg-purple-900/30"></div>
+              <div class="flex-1">
+                <div class="mb-2 h-5 w-1/2 animate-pulse rounded-md bg-white/10"></div>
+                <div class="h-4 w-3/4 animate-pulse rounded-md bg-white/10"></div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- 두 번째 날짜 -->
+        <div class="rounded-lg border border-white/10 bg-white/5 p-3">
+          <div class="mb-3 flex items-center border-b border-white/10 pb-2">
+            <div class="h-5 w-1/4 animate-pulse rounded-md bg-white/10"></div>
+          </div>
+
+          <!-- 일정 아이템들 -->
+          <div class="space-y-3">
+            <div v-for="i in 2" :key="i" class="flex gap-3 rounded-lg p-2">
+              <div class="h-8 w-8 animate-pulse rounded-full bg-purple-900/30"></div>
+              <div class="flex-1">
+                <div class="mb-2 h-5 w-1/2 animate-pulse rounded-md bg-white/10"></div>
+                <div class="h-4 w-3/4 animate-pulse rounded-md bg-white/10"></div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+// No props or logic needed for skeleton
+</script>

--- a/front_end/src/components/views/plan/PlanDetail/PlanInfo.vue
+++ b/front_end/src/components/views/plan/PlanDetail/PlanInfo.vue
@@ -1,0 +1,71 @@
+<template>
+  <Card class="border-0 bg-slate-900/30 shadow-none">
+    <CardContent class="space-y-3 p-3">
+      <div class="flex items-center justify-between">
+        <div class="flex flex-wrap gap-2">
+          <Tag
+            v-for="tag in tags"
+            :key="tag.tagId"
+            :label="tag.name || `태그 ${tag.tagId}`"
+            class="rounded-md border-purple-400/50 bg-purple-900/20 text-purple-200"
+          />
+        </div>
+        <Button
+          variant="ghost"
+          size="sm"
+          class="flex items-center gap-1.5 text-purple-200 hover:bg-purple-900/30"
+          @click="$emit('toggleLike')"
+        >
+          <Heart v-if="isLiked" class="h-4 w-4 fill-purple-400 text-purple-400" />
+          <Heart v-else class="h-4 w-4 text-gray-300" />
+          <span class="text-sm font-medium">{{ likeCount }}</span>
+        </Button>
+      </div>
+
+      <h2 class="text-xl font-bold text-white">{{ title }}</h2>
+
+      <div class="flex items-start gap-2 text-sm text-gray-300">
+        <Calendar class="mt-0.5 h-4 w-4 flex-shrink-0 text-purple-400" />
+        <span>{{ dateRange }}</span>
+      </div>
+
+      <div v-if="description" class="mt-2 text-sm text-gray-300">
+        {{ description }}
+      </div>
+
+      <div class="flex items-start gap-2 text-sm text-gray-300">
+        <Users class="mt-0.5 h-4 w-4 flex-shrink-0 text-purple-400" />
+        <div class="flex flex-wrap gap-1">
+          <span
+            v-for="writer in writers"
+            :key="writer.userId"
+            class="inline-block rounded-full bg-purple-900/30 px-2 py-0.5"
+          >
+            {{ writer.name }}
+          </span>
+        </div>
+      </div>
+    </CardContent>
+  </Card>
+</template>
+
+<script setup lang="ts">
+import { Heart, Calendar, Users } from 'lucide-vue-next';
+import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import Tag from '@/components/common/Tag/Tag.vue';
+
+defineProps<{
+  title?: string;
+  dateRange: string;
+  description?: string;
+  tags?: { tagId: number; name: string }[];
+  writers?: { userId: number; name: string }[];
+  likeCount: number;
+  isLiked?: boolean;
+}>();
+
+defineEmits<{
+  (e: 'toggleLike'): void;
+}>();
+</script>

--- a/front_end/src/components/views/plan/PlanDetail/PlanInfo.vue
+++ b/front_end/src/components/views/plan/PlanDetail/PlanInfo.vue
@@ -55,7 +55,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import Tag from '@/components/common/Tag/Tag.vue';
 
-defineProps<{
+const props = defineProps<{
   title?: string;
   dateRange: string;
   description?: string;
@@ -69,7 +69,7 @@ const emit = defineEmits<{
   toggleLike: [planId: number];
 }>();
 
-const handleClick = (planId: number) => {
-  emit('toggleLike', planId);
+const handleClick = () => {
+  emit('toggleLike', props.planId);
 };
 </script>

--- a/front_end/src/components/views/plan/PlanDetail/PlanInfo.vue
+++ b/front_end/src/components/views/plan/PlanDetail/PlanInfo.vue
@@ -14,7 +14,7 @@
           variant="ghost"
           size="sm"
           class="flex items-center gap-1.5 text-purple-200 hover:bg-purple-900/30"
-          @click="$emit('toggleLike')"
+          @click="handleClick"
         >
           <Heart v-if="isLiked" class="h-4 w-4 fill-purple-400 text-purple-400" />
           <Heart v-else class="h-4 w-4 text-gray-300" />
@@ -65,7 +65,11 @@ defineProps<{
   isLiked?: boolean;
 }>();
 
-defineEmits<{
-  (e: 'toggleLike'): void;
+const emit = defineEmits<{
+  toggleLike: [planId: number];
 }>();
+
+const handleClick = (planId: number) => {
+  emit('toggleLike', planId);
+};
 </script>

--- a/front_end/src/components/views/plan/PlanDetail/StellaHeader.vue
+++ b/front_end/src/components/views/plan/PlanDetail/StellaHeader.vue
@@ -1,0 +1,32 @@
+<template>
+  <div class="relative h-40 w-full bg-indigo-950">
+    <!-- 별자리가 있으면 표시, 없으면 기본 배경 -->
+    <div v-if="stella" class="h-full w-full">
+      <Constellation
+        :stars="stella.stars"
+        :connections="stella.connections"
+        :backgroundStars="backgroundStars"
+        :isHovered="false"
+      />
+    </div>
+    <div
+      v-else
+      class="absolute inset-0 bg-gradient-to-br from-slate-900 via-purple-950 to-indigo-950 opacity-70"
+    ></div>
+    <div
+      class="absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent"
+    ></div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import Constellation from '@/components/common/Constellation/Constellation.vue';
+
+defineProps<{
+  stella?: {
+    stars: any[];
+    connections: any[];
+  };
+  backgroundStars: any[];
+}>();
+</script>

--- a/front_end/src/components/views/plan/PlanDetail/index.ts
+++ b/front_end/src/components/views/plan/PlanDetail/index.ts
@@ -1,0 +1,3 @@
+export { default as PlanDetail } from './PlanDetail.vue';
+export { default as PlanDetailSkeleton } from './PlanDetailSkeleton.vue';
+export { default as PlanDetailError } from './PlanDetailError.vue';

--- a/front_end/src/components/views/plan/PlanFilter.vue
+++ b/front_end/src/components/views/plan/PlanFilter.vue
@@ -1,0 +1,252 @@
+<template>
+  <div ref="containerRef">
+    <!-- 검색 필드 -->
+    <div class="relative mx-4">
+      <div class="absolute inset-0 -z-10 rounded-md bg-slate-900/80 backdrop-blur-md"></div>
+      <Input
+        v-model="searchQuery"
+        placeholder="여행 계획 검색"
+        class="relative h-11 border-purple-400/50 bg-slate-800/70 pr-10 text-base text-white placeholder-purple-200/70 shadow-md backdrop-blur-md"
+        @focus="isSearchFocused = true"
+        @keyup.enter="handleSearch"
+      />
+      <Button
+        variant="ghost"
+        size="icon"
+        class="absolute top-0 right-0 h-full text-purple-400 hover:text-purple-300"
+        @click="handleSearch"
+      >
+        <Search class="h-5 w-5" />
+      </Button>
+    </div>
+
+    <!-- 펼쳐지는 필터 영역 -->
+    <div
+      class="overflow-hidden px-4 transition-all duration-300"
+      :class="isSearchFocused ? 'max-h-96 opacity-100' : 'max-h-0 opacity-0'"
+    >
+      <Card
+        class="mt-2 space-y-4 border-purple-500/20 bg-slate-900/90 p-4 text-white shadow-md backdrop-blur-md"
+      >
+        <!-- 기간 선택 -->
+        <div class="space-y-2">
+          <Label class="text-sm font-medium text-purple-200/80">여행 기간</Label>
+          <div class="flex flex-wrap gap-2">
+            <Badge
+              v-for="(days, index) in durationOptions"
+              :key="index"
+              :variant="selectedDuration === days ? 'default' : 'outline'"
+              class="cursor-pointer border-purple-400/30 bg-slate-800 py-1.5 text-sm text-white transition-all hover:bg-slate-700"
+              :class="{
+                'border-purple-500/50 bg-purple-600 text-white hover:bg-purple-500':
+                  selectedDuration === days,
+              }"
+              @click="toggleDuration(days)"
+            >
+              {{ formatDurationLabel(days) }}
+            </Badge>
+          </div>
+        </div>
+
+        <!-- 정렬 방식 선택 -->
+        <div class="space-y-2">
+          <Label class="text-sm font-medium text-purple-200/80">정렬 방식</Label>
+          <div class="flex flex-wrap gap-2">
+            <Badge
+              v-for="(label, value) in sortOptions"
+              :key="value"
+              :variant="selectedSort === value ? 'default' : 'outline'"
+              class="cursor-pointer border-purple-400/30 bg-slate-800 py-1.5 text-sm text-white transition-all hover:bg-slate-700"
+              :class="{
+                'border-purple-500/50 bg-purple-600 text-white hover:bg-purple-500':
+                  selectedSort === value,
+              }"
+              @click="selectedSort = value"
+            >
+              {{ label }}
+            </Badge>
+          </div>
+        </div>
+
+        <!-- 작성자 이름 입력 -->
+        <div class="space-y-2">
+          <Label class="text-sm font-medium text-purple-200/80">작성자</Label>
+          <Input
+            v-model="userName"
+            placeholder="작성자 이름"
+            class="border-purple-400/50 bg-slate-800/70 text-white placeholder-purple-200/70"
+          />
+        </div>
+
+        <!-- 필터 적용/초기화 버튼 -->
+        <div class="flex items-center justify-between pt-2">
+          <Button
+            variant="outline"
+            size="sm"
+            class="border-purple-400/40 bg-slate-800 text-white hover:bg-purple-500/20 hover:text-white"
+            @click="resetFilters"
+          >
+            초기화
+          </Button>
+          <Button
+            size="sm"
+            class="bg-purple-600 text-white hover:bg-purple-500"
+            @click="applyFilters"
+          >
+            필터 적용
+          </Button>
+        </div>
+      </Card>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted, onBeforeUnmount, watch, type PropType } from 'vue';
+import { Search } from 'lucide-vue-next';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Label } from '@/components/ui/label';
+
+type SortOption = 'RECENT' | 'POPULAR';
+
+const props = defineProps({
+  parentScrollContainer: {
+    type: Object as PropType<HTMLElement | null>,
+    default: null,
+  },
+  isScrollingDown: {
+    type: Boolean,
+    default: false,
+  },
+  scrollY: {
+    type: Number,
+    default: 0,
+  },
+});
+
+const emit = defineEmits<{
+  (
+    e: 'filter',
+    filters: {
+      search?: string;
+      userName?: string;
+      duration?: number;
+      sort?: SortOption;
+    }
+  ): void;
+}>();
+
+// 여행 기간 옵션 (일 수)
+const durationOptions = [0, 1, 2, 3, 7, 14];
+
+// 정렬 옵션
+const sortOptions = {
+  RECENT: '최신순',
+  POPULAR: '인기순',
+};
+
+const isSearchFocused = ref(false);
+const containerRef = ref<HTMLElement | null>(null);
+
+const searchQuery = ref('');
+const userName = ref('');
+const selectedDuration = ref<number | null>(null);
+const selectedSort = ref<SortOption>('RECENT');
+
+// 스크롤 상태 변화 감지
+watch([() => props.isScrollingDown, () => props.scrollY], ([newIsScrollingDown, newScrollY]) => {
+  if (newIsScrollingDown && newScrollY > 30 && isSearchFocused.value) {
+    isSearchFocused.value = false;
+  }
+});
+
+// 외부 클릭 감지용 이벤트 핸들러
+const handleClickOutside = (event: MouseEvent) => {
+  if (
+    containerRef.value &&
+    !containerRef.value.contains(event.target as Node) &&
+    isSearchFocused.value
+  ) {
+    closeFilterPanel();
+  }
+};
+
+// 필터 패널 닫기 메소드
+const closeFilterPanel = () => {
+  if (isSearchFocused.value) {
+    isSearchFocused.value = false;
+  }
+};
+
+// 부모 컴포넌트에 메소드 노출
+defineExpose({
+  closeFilterPanel,
+});
+
+onMounted(() => {
+  document.addEventListener('mousedown', handleClickOutside);
+});
+
+onBeforeUnmount(() => {
+  document.removeEventListener('mousedown', handleClickOutside);
+});
+
+// 여행 기간 포맷
+const formatDurationLabel = (days: number) => {
+  if (days === 0) return '전체';
+  if (days === 1) return '당일';
+  return `${days}일`;
+};
+
+// 여행 기간 토글 핸들러
+const toggleDuration = (days: number) => {
+  if (selectedDuration.value === days) {
+    selectedDuration.value = null;
+  } else {
+    selectedDuration.value = days;
+  }
+};
+
+// 필터 초기화
+const resetFilters = () => {
+  searchQuery.value = '';
+  userName.value = '';
+  selectedDuration.value = null;
+  selectedSort.value = 'RECENT';
+};
+
+// 검색 핸들러
+const handleSearch = () => {
+  applyFilters();
+};
+
+// 필터 적용
+const applyFilters = () => {
+  const filters: {
+    search?: string;
+    userName?: string;
+    duration?: number;
+    sort?: SortOption;
+  } = {
+    sort: selectedSort.value,
+  };
+
+  if (searchQuery.value) {
+    filters.search = searchQuery.value;
+  }
+
+  if (userName.value) {
+    filters.userName = userName.value;
+  }
+
+  if (selectedDuration.value !== null && selectedDuration.value > 0) {
+    filters.duration = selectedDuration.value;
+  }
+
+  emit('filter', filters);
+  isSearchFocused.value = false;
+};
+</script>

--- a/front_end/src/composables/useMapState.ts
+++ b/front_end/src/composables/useMapState.ts
@@ -273,12 +273,7 @@ watch(
           bounds.extend(new window.kakao.maps.LatLng(marker.lat, marker.lng));
         });
 
-        // 약간의 지연을 주어 지도가 완전히 초기화된 후 bounds 설정
-        setTimeout(() => {
-          if (mapRef.value?.map) {
-            mapRef.value.map.setBounds(bounds);
-          }
-        }, 100);
+        mapRef.value?.map.setBounds(bounds);
       }
     }
   }

--- a/front_end/src/composables/useMapState.ts
+++ b/front_end/src/composables/useMapState.ts
@@ -1,48 +1,264 @@
-import { ref, computed, type ComputedRef } from 'vue';
+import { ref, computed, watch, type ComputedRef } from 'vue';
 import type { Attraction } from '@/services/api/domains/attraction';
+import type { Plan, PlanDetail } from '@/services/api/domains/plan';
 import type MapContainer from '@/components/map/MapContainer.vue';
+
+interface MarkerInfo {
+  lat: number;
+  lng: number;
+  name: string;
+  order?: number;
+  date?: string;
+}
+
+// Kakao 맵 마커 객체 타입 정의
+type KakaoMarker = {
+  setMap: (map: any | null) => void;
+  [key: string]: any;
+};
 
 interface UseMapStateReturn {
   mapRef: ReturnType<typeof ref<InstanceType<typeof MapContainer> | null>>;
   selectedAttraction: ReturnType<typeof ref<Attraction | null>>;
+  selectedPlan: ReturnType<typeof ref<Plan | null>>;
   mapLevel: ReturnType<typeof ref<number>>;
   mapCenter: ComputedRef<{ lat: number; lng: number }>;
+  markers: ReturnType<typeof ref<MarkerInfo[]>>;
   selectAttraction: (attraction: Attraction) => void;
+  selectPlan: (plan: Plan) => void;
+  selectPlanDetail: (planDetail: PlanDetail) => void;
+  clearMarkers: () => void;
+  showAllMarkers: () => void;
 }
 
-export function useMapState(): UseMapStateReturn {
-  const mapRef = ref<InstanceType<typeof MapContainer> | null>(null);
-  const selectedAttraction = ref<Attraction | null>(null);
-  const defaultCenter = { lat: 37.5665, lng: 126.978 };
-  const mapLevel = ref(7);
+// 싱글톤으로 작동
+const mapRef = ref<InstanceType<typeof MapContainer> | null>(null);
+const selectedAttraction = ref<Attraction | null>(null);
+const selectedPlan = ref<Plan | null>(null);
+const defaultCenter = { lat: 37.5665, lng: 126.978 };
+const mapLevel = ref(7);
+const markers = ref<MarkerInfo[]>([]);
+const markersObjects = ref<KakaoMarker[]>([]);
 
-  const mapCenter = computed(() => {
-    if (
-      selectedAttraction.value?.latitude !== undefined &&
-      selectedAttraction.value?.longitude !== undefined
-    ) {
-      return {
-        lat: selectedAttraction.value.latitude,
-        lng: selectedAttraction.value.longitude,
-      };
+// 마커 초기화 함수
+const clearMarkers = () => {
+  if (!mapRef.value) return;
+
+  // 중앙 마커 숨기기
+  mapRef.value.hideMarker();
+
+  // Kakao Maps API를 사용하여 추가한 마커 제거
+  try {
+    if (window.kakao?.maps && mapRef.value.map && markersObjects.value.length > 0) {
+      markersObjects.value.forEach(marker => marker.setMap(null));
+      markersObjects.value = [];
     }
-    return defaultCenter;
+  } catch (error) {
+    console.error('마커 제거 중 오류:', error);
+  }
+
+  // 마커 정보 배열 초기화
+  markers.value = [];
+};
+
+// 관광지 선택 시 핸들러
+const selectAttraction = (attraction: Attraction) => {
+  if (!attraction) return;
+
+  selectedAttraction.value = attraction;
+  selectedPlan.value = null;
+  clearMarkers();
+
+  if (attraction.latitude !== undefined && attraction.longitude !== undefined && mapRef.value) {
+    mapRef.value.panTo(attraction.latitude, attraction.longitude);
+    mapRef.value.setLevel(3);
+    mapRef.value.showMarker(attraction.latitude, attraction.longitude);
+  }
+};
+
+// 여행 계획 선택 시 핸들러
+const selectPlan = (plan: Plan) => {
+  if (!plan) return;
+
+  selectedPlan.value = plan;
+  selectedAttraction.value = null;
+};
+
+// 여행 계획 상세 정보 처리 핸들러
+const selectPlanDetail = (planDetail: PlanDetail) => {
+  if (!planDetail) return;
+
+  // 마커 초기화
+  clearMarkers();
+
+  // 모든 여행 일정에서 방문 장소 추출
+  const allAttractions: MarkerInfo[] = [];
+
+  if (planDetail.details) {
+    Object.entries(planDetail.details).forEach(([date, attractions]) => {
+      attractions.forEach(attraction => {
+        // 좌표 검증 및 처리
+        const lat = parseFloat(String(attraction.latitude));
+        const lng = parseFloat(String(attraction.longitude));
+
+        if (!isNaN(lat) && !isNaN(lng)) {
+          allAttractions.push({
+            lat,
+            lng,
+            name: attraction.name,
+            order: attraction.order,
+            date: date,
+          });
+        }
+      });
+    });
+  }
+
+  // 마커 정보 설정
+  markers.value = allAttractions;
+
+  if (markers.value.length > 0 && mapRef.value) {
+    // 모든 마커를 표시
+    showAllMarkers();
+
+    // 카카오맵 bounds 설정
+    if (window.kakao?.maps && mapRef.value.map) {
+      // 모든 마커를 포함하는 경계 생성
+      const bounds = new window.kakao.maps.LatLngBounds();
+
+      // 모든 마커 좌표를 경계에 추가
+      markers.value.forEach(marker => {
+        bounds.extend(new window.kakao.maps.LatLng(marker.lat, marker.lng));
+      });
+
+      // 경계에 맞게 지도 조정 (모든 마커가 보이도록)
+      mapRef.value.map.setBounds(bounds);
+
+      // 경계 설정 후 약간의 지도 레벨 조정 (여백을 위해)
+      const currentLevel = mapRef.value.map.getLevel();
+      mapRef.value.map.setLevel(currentLevel);
+
+      // 상태 변수 업데이트
+      mapLevel.value = currentLevel;
+    }
+  }
+};
+
+// 모든 마커 표시 함수
+const showAllMarkers = () => {
+  if (!mapRef.value || !mapRef.value.map || markers.value.length === 0) return false;
+
+  // 중앙 마커 숨기기
+  mapRef.value.hideMarker();
+
+  // 카카오맵 API 확인
+  if (!window.kakao?.maps) return false;
+
+  // 이전 마커 객체들 제거
+  markersObjects.value.forEach(marker => marker.setMap(null));
+  markersObjects.value = [];
+
+  // 각 위치에 마커 생성 및 표시
+  markers.value.forEach(markerInfo => {
+    // 좌표 유효성 확인
+    if (!markerInfo.lat || !markerInfo.lng) return;
+
+    const position = new window.kakao.maps.LatLng(markerInfo.lat, markerInfo.lng);
+
+    // 마커 생성 (색상이 있는 마커로 변경)
+    const marker = new window.kakao.maps.Marker({
+      position: position,
+      map: mapRef.value?.map,
+      // 날짜별로 다른 색상의 마커 사용
+      image: new window.kakao.maps.MarkerImage(
+        'https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/markerStar.png',
+        new window.kakao.maps.Size(24, 35)
+      ),
+    });
+
+    // 정보창 (마커 클릭 시 표시되는 정보)
+    const infoContent = `
+          <div style="padding:8px;font-size:12px;max-width:200px;word-break:keep-all;">
+            <div style="font-weight:bold;margin-bottom:4px;color:#333;">${markerInfo.name}</div> 
+            ${markerInfo.order ? `<div style="color:#666;">방문 순서: ${markerInfo.order}</div>` : ''}
+            ${markerInfo.date ? `<div style="color:#666;">날짜: ${markerInfo.date}</div>` : ''}
+          </div>
+        `;
+    const infoWindow = new window.kakao.maps.InfoWindow({
+      content: infoContent,
+      removable: true,
+    });
+
+    // 마커 클릭 시 다른 정보창은 닫고 이 마커의 정보창만 표시
+    window.kakao.maps.event.addListener(marker, 'click', () => {
+      // 다른 정보창 닫기 로직 추가 가능
+      infoWindow.open(mapRef.value?.map, marker);
+    });
+
+    // 마커 객체 저장
+    markersObjects.value.push(marker);
   });
 
-  const selectAttraction = (attraction: Attraction) => {
-    selectedAttraction.value = attraction;
+  return true;
+};
 
-    if (attraction.latitude !== undefined && attraction.longitude !== undefined && mapRef.value) {
-      mapRef.value.panTo(attraction.latitude, attraction.longitude);
-      mapRef.value.setLevel(3);
+// mapCenter 계산 속성 - 간소화됨
+const mapCenter = computed(() => {
+  if (
+    selectedAttraction.value?.latitude !== undefined &&
+    selectedAttraction.value?.longitude !== undefined
+  ) {
+    return {
+      lat: selectedAttraction.value.latitude,
+      lng: selectedAttraction.value.longitude,
+    };
+  }
+
+  // 기본 중심점 반환
+  return defaultCenter;
+});
+
+// 지도 참조 변경 감지 - 마커를 다시 그리고 bounds 설정
+watch(
+  () => mapRef.value?.map,
+  newMap => {
+    if (newMap && markers.value.length > 0) {
+      // 마커 다시 그리기
+      showAllMarkers();
+
+      // bounds 설정으로 모든 마커 표시
+      if (window.kakao?.maps) {
+        const bounds = new window.kakao.maps.LatLngBounds();
+
+        markers.value.forEach(marker => {
+          bounds.extend(new window.kakao.maps.LatLng(marker.lat, marker.lng));
+        });
+
+        // 약간의 지연을 주어 지도가 완전히 초기화된 후 bounds 설정
+        setTimeout(() => {
+          if (mapRef.value?.map) {
+            mapRef.value.map.setBounds(bounds);
+          }
+        }, 100);
+      }
     }
-  };
+  }
+);
 
+// 싱글톤 컴포저블 함수 정의
+export function useMapState(): UseMapStateReturn {
+  // 이미 생성된 싱글톤 상태와 메서드 반환
   return {
     mapRef,
     selectedAttraction,
+    selectedPlan,
     mapLevel,
     mapCenter,
+    markers,
     selectAttraction,
+    selectPlan,
+    selectPlanDetail,
+    clearMarkers,
+    showAllMarkers,
   };
 }

--- a/front_end/src/composables/useMapState.ts
+++ b/front_end/src/composables/useMapState.ts
@@ -44,19 +44,13 @@ const markersObjects = ref<KakaoMarker[]>([]);
 
 // 마커 초기화 함수
 const clearMarkers = () => {
-  if (!mapRef.value) return;
-
   // 중앙 마커 숨기기
-  mapRef.value.hideMarker();
+  mapRef.value?.hideMarker();
 
   // Kakao Maps API를 사용하여 추가한 마커 제거
-  try {
-    if (window.kakao?.maps && mapRef.value.map && markersObjects.value.length > 0) {
-      markersObjects.value.forEach(marker => marker.setMap(null));
-      markersObjects.value = [];
-    }
-  } catch (error) {
-    console.error('마커 제거 중 오류:', error);
+  if (window.kakao?.maps && mapRef.value?.map && markersObjects.value.length > 0) {
+    markersObjects.value.forEach(marker => marker.setMap(null));
+    markersObjects.value = [];
   }
 
   // 마커 정보 배열 초기화
@@ -88,8 +82,6 @@ const selectPlan = (plan: Plan) => {
 
 // 여행 계획 상세 정보 처리 핸들러
 const selectPlanDetail = (planDetail: PlanDetail) => {
-  if (!planDetail) return;
-
   // 마커 초기화
   clearMarkers();
 
@@ -162,7 +154,6 @@ const showAllMarkers = () => {
 
   // 각 위치에 마커 생성 및 표시
   markers.value.forEach(markerInfo => {
-    // 좌표 유효성 확인
     if (!markerInfo.lat || !markerInfo.lng) return;
 
     const position = new window.kakao.maps.LatLng(markerInfo.lat, markerInfo.lng);

--- a/front_end/src/composables/usePlanFilter.ts
+++ b/front_end/src/composables/usePlanFilter.ts
@@ -1,4 +1,5 @@
 import { ref } from 'vue';
+import PlanFilter from '@/components/views/plan/PlanFilter.vue';
 
 type SortOption = 'RECENT' | 'POPULAR';
 
@@ -10,7 +11,7 @@ interface FilterParams {
 }
 
 export function usePlanFilter() {
-  const filterComponentRef = ref(null);
+  const filterComponentRef = ref<InstanceType<typeof PlanFilter> | null>(null);
   const currentFilters = ref<FilterParams>({
     sort: 'RECENT',
   });
@@ -21,8 +22,8 @@ export function usePlanFilter() {
   };
 
   const closeFilterPanel = () => {
-    if (filterComponentRef.value && 'closeFilterPanel' in filterComponentRef.value) {
-      (filterComponentRef.value as any).closeFilterPanel();
+    if (filterComponentRef.value) {
+      filterComponentRef.value.closeFilterPanel();
     }
   };
 

--- a/front_end/src/composables/usePlanFilter.ts
+++ b/front_end/src/composables/usePlanFilter.ts
@@ -1,0 +1,35 @@
+import { ref } from 'vue';
+
+type SortOption = 'RECENT' | 'POPULAR';
+
+interface FilterParams {
+  search?: string;
+  userName?: string;
+  duration?: number;
+  sort?: SortOption;
+}
+
+export function usePlanFilter() {
+  const filterComponentRef = ref(null);
+  const currentFilters = ref<FilterParams>({
+    sort: 'RECENT',
+  });
+
+  const handleFilterChange = (filters: FilterParams) => {
+    currentFilters.value = filters;
+    // TODO: 여기서 필터링된 데이터를 가져오는 API 호출 등의 작업을 수행할 수 있습니다.
+  };
+
+  const closeFilterPanel = () => {
+    if (filterComponentRef.value && 'closeFilterPanel' in filterComponentRef.value) {
+      (filterComponentRef.value as any).closeFilterPanel();
+    }
+  };
+
+  return {
+    filterComponentRef,
+    currentFilters,
+    handleFilterChange,
+    closeFilterPanel,
+  };
+}

--- a/front_end/src/router/index.ts
+++ b/front_end/src/router/index.ts
@@ -28,6 +28,25 @@ const routes: Array<RouteRecordRaw> = [
     },
   },
   {
+    path: ROUTES.PLANS.path,
+    name: ROUTES.PLANS.name,
+    component: () => import('@/views/Plan.vue'),
+    meta: {
+      title: ROUTES.PLANS.title,
+    },
+    children: [
+      {
+        path: ROUTES.PLAN_DETAIL.path,
+        name: ROUTES.PLAN_DETAIL.name,
+        component: () => import('@/views/PlanDetail.vue'),
+        meta: {
+          title: ROUTES.PLAN_DETAIL.title,
+        },
+        props: true,
+      },
+    ],
+  },
+  {
     path: ROUTES.NOT_FOUND.path,
     name: ROUTES.NOT_FOUND.name,
     component: () => import('@/views/NotFound.vue'),

--- a/front_end/src/router/routes.ts
+++ b/front_end/src/router/routes.ts
@@ -2,5 +2,7 @@ export const ROUTES = {
   HOME: { path: '/', name: 'home', title: '메인페이지' },
   MAIN: { path: '/main', name: 'main', title: '메인페이지' },
   ATTRACTION: { path: '/attractions', name: 'attractions', title: '여행지 검색' },
+  PLANS: { path: '/plans', name: 'plans', title: '여행 계획 목록' },
+  PLAN_DETAIL: { path: '/plans/:planId', name: 'plan-detail', title: '여행 계획 상세' },
   NOT_FOUND: { path: '/:pathMatch(.*)*', name: 'not-found', title: '존재하지 않는 페이지' },
 } as const;

--- a/front_end/src/services/api/domains/plan/index.ts
+++ b/front_end/src/services/api/domains/plan/index.ts
@@ -1,7 +1,7 @@
 import { PLAN } from '../../endpoint';
 import api from '../../api';
 import type { ApiResponse, PagenationResponse } from '../../types';
-import type { Plan, PlansParams, Tag } from './types';
+import type { Plan, PlansParams, Tag, PlanDetail } from './types';
 
 /**
  * query parameter를 바탕으로 여행 계획 리스트 조회
@@ -21,6 +21,17 @@ export const getPlans = async (params?: PlansParams): Promise<PagenationResponse
  */
 export const getPopularTags = async (size?: number): Promise<Tag[]> => {
   const response = await api.get<ApiResponse<Tag[]>>(PLAN.TAGS, { params: { size } });
+
+  return response.data.body;
+};
+
+/**
+ * 여행 계획 상세 정보 조회
+ * @param planId planId
+ * @returns 여행 계획 상세 정보
+ */
+export const getPlanDetail = async (planId: number): Promise<PlanDetail> => {
+  const response = await api.get<ApiResponse<PlanDetail>>(PLAN.DETAIL(planId));
 
   return response.data.body;
 };

--- a/front_end/src/services/api/domains/plan/types.ts
+++ b/front_end/src/services/api/domains/plan/types.ts
@@ -31,3 +31,50 @@ export type Writer = {
   userId: number;
   name: string;
 };
+
+export type RouteAttraction = {
+  order: number;
+  name: string;
+  image: string;
+  address: string;
+  latitude: number;
+  longitude: number;
+  memo: string | null;
+  routeId: number;
+  attractionId: number;
+  contentTypeId: number;
+  likeCount: number;
+  rating: number;
+  visitTime: string;
+};
+
+export type PlanDetails = {
+  [date: string]: RouteAttraction[];
+};
+
+export type PlanDetail = {
+  planId: number;
+  title: string;
+  description: string | null;
+  stella: {
+    stars: Array<{
+      x: number;
+      y: number;
+      r: number;
+      brightness: number;
+      delay: number;
+    }>;
+    connections: Array<{
+      from: number;
+      to: number;
+    }>;
+  } | null;
+  likeCount: number;
+  tags: Tag[];
+  isLiked: boolean;
+  details: PlanDetails;
+  isPublic: boolean;
+  startDate: string;
+  endDate: string;
+  planWriters: Writer[];
+};

--- a/front_end/src/types/kakao.d.ts
+++ b/front_end/src/types/kakao.d.ts
@@ -3,6 +3,7 @@ declare global {
   interface Window {
     kakao: {
       maps: {
+        LatLngBounds: any;
         load: (callback: () => void) => void;
         LatLng: new (lat: number, lng: number) => any;
         Map: new (container: HTMLElement, options: any) => any;

--- a/front_end/src/views/Attraction.vue
+++ b/front_end/src/views/Attraction.vue
@@ -25,7 +25,7 @@
           >
             <AsyncContainer
               :loadingComponent="FilteredAttractionsSkeleton"
-              :errorComponent="AttractionsError"
+              :errorComponent="FilteredAttractionsError"
             >
               <FilteredAttractions
                 :parentScrollContainer="scrollContainerRef"
@@ -83,10 +83,10 @@ import HeroBackground from '@/components/background/HeroBackground.vue';
 import AsyncContainer from '@/components/AsyncContainer/AsyncContainer.vue';
 import MapContainer from '@/components/map/MapContainer.vue';
 import MapError from '@/components/map/MapError.vue';
-import { AttractionsError } from '@/components/views/main/AttractionsSection';
 import {
   FilteredAttractionsSkeleton,
   FilteredAttractions,
+  FilteredAttractionsError,
 } from '@/components/views/attraction/FilteredAttractions';
 import AttractionFilter from '@/components/views/attraction/AttractionFilter.vue';
 import NavigationBar from '@/components/NavigationBar/NavigationBar.vue';

--- a/front_end/src/views/Plan.vue
+++ b/front_end/src/views/Plan.vue
@@ -98,7 +98,6 @@ const { isScrollingDown, scrollY, handleScroll } = useScroll();
 // 지도 리사이즈 핸들러
 const handleMapResize = () => {
   if (mapRef.value?.refreshMap) {
-    console.log('지도 리사이즈 감지, refreshMap 호출');
     mapRef.value.refreshMap();
   }
 };
@@ -106,9 +105,7 @@ const handleMapResize = () => {
 // 여행 계획 카드 클릭 핸들러
 const handlePlanCardClick = (plan: Plan) => {
   // 기본 정보 설정 (지도 표시용)
-  if (typeof selectPlan === 'function') {
-    selectPlan(plan);
-  }
+  selectPlan(plan);
 
   // 선택한 계획의 상세 페이지로 이동
   router.push({

--- a/front_end/src/views/Plan.vue
+++ b/front_end/src/views/Plan.vue
@@ -1,0 +1,128 @@
+<template>
+  <HeroBackground />
+  <div class="h-screen">
+    <NavigationBar />
+    <section class="relative h-[calc(100vh-4rem)]">
+      <ResizablePanelGroup direction="horizontal" class="h-full">
+        <!-- 왼쪽 섹션 (필터 + 그리드 또는 상세 정보) -->
+        <ResizablePanel :defaultSize="33" :minSize="20" :maxSize="60" class="relative">
+          <!-- 라우터 뷰를 통해 자식 컴포넌트(PlanDetail) 렌더링 -->
+          <router-view v-slot="{ Component }">
+            <template v-if="Component">
+              <component :is="Component" :mapRef="mapRef" />
+            </template>
+            <template v-else>
+              <!-- 기존 Plan 콘텐츠 (필터 + 그리드) -->
+              <div
+                class="absolute top-0 left-0 z-10 h-fit w-full p-2 transition-transform duration-300"
+                :class="{ '-translate-y-full': isScrollingDown && scrollY > 100 }"
+              >
+                <PlanFilter
+                  ref="filterComponentRef"
+                  :isScrollingDown="isScrollingDown"
+                  :scrollY="scrollY"
+                  @filter="handleFilterChange"
+                />
+              </div>
+              <div
+                ref="scrollContainerRef"
+                class="h-full overflow-x-hidden overflow-y-auto px-2 pt-12"
+                @scroll="e => handleScroll(e, closeFilterPanel)"
+              >
+                <AsyncContainer
+                  :loadingComponent="FilteredPlansSkeleton"
+                  :errorComponent="FilteredPlansError"
+                >
+                  <FilteredPlans
+                    :parentScrollContainer="scrollContainerRef"
+                    :apiParams="{ page: 1, size: 100 }"
+                    @cardClick="handlePlanCardClick"
+                    @likeClick="handlePlanLikeClick"
+                    @tagClick="handlePlanTagClick"
+                  />
+                </AsyncContainer>
+              </div>
+            </template>
+          </router-view>
+        </ResizablePanel>
+
+        <ResizableHandle withHandle />
+
+        <!-- 오른쪽: 지도 -->
+        <ResizablePanel :defaultSize="67" class="relative" @resizeend="handleMapResize">
+          <AsyncContainer :loadingComponent="CommonSkeleton" :errorComponent="MapError">
+            <MapContainer
+              ref="mapRef"
+              :center="mapCenter"
+              :level="mapLevel"
+              :showCenterMarker="false"
+            />
+          </AsyncContainer>
+        </ResizablePanel>
+      </ResizablePanelGroup>
+    </section>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import { useRouter } from 'vue-router';
+import HeroBackground from '@/components/background/HeroBackground.vue';
+import AsyncContainer from '@/components/AsyncContainer/AsyncContainer.vue';
+import MapContainer from '@/components/map/MapContainer.vue';
+import MapError from '@/components/map/MapError.vue';
+import {
+  FilteredPlansSkeleton,
+  FilteredPlans,
+  FilteredPlansError,
+} from '@/components/views/plan/FilteredPlans';
+import PlanFilter from '@/components/views/plan/PlanFilter.vue';
+import NavigationBar from '@/components/NavigationBar/NavigationBar.vue';
+import CommonSkeleton from '@/components/skeleton/CommonSkeleton/CommonSkeleton.vue';
+import { type Plan, type Tag } from '@/services/api/domains/plan';
+import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from '@/components/ui/resizable';
+import { useMapState } from '@/composables/useMapState';
+import { useScroll } from '@/composables/useScroll';
+import { usePlanFilter } from '@/composables/usePlanFilter';
+import { ROUTES } from '@/router/routes';
+
+// Vue Router
+const router = useRouter();
+
+// 상태 관리
+const scrollContainerRef = ref<HTMLElement | null>(null);
+const { mapRef, mapLevel, mapCenter, selectPlan } = useMapState();
+const { filterComponentRef, handleFilterChange, closeFilterPanel } = usePlanFilter();
+const { isScrollingDown, scrollY, handleScroll } = useScroll();
+
+// 지도 리사이즈 핸들러
+const handleMapResize = () => {
+  if (mapRef.value?.refreshMap) {
+    console.log('지도 리사이즈 감지, refreshMap 호출');
+    mapRef.value.refreshMap();
+  }
+};
+
+// 여행 계획 카드 클릭 핸들러
+const handlePlanCardClick = (plan: Plan) => {
+  // 기본 정보 설정 (지도 표시용)
+  if (typeof selectPlan === 'function') {
+    selectPlan(plan);
+  }
+
+  // 선택한 계획의 상세 페이지로 이동
+  router.push({
+    name: ROUTES.PLAN_DETAIL.name,
+    params: { planId: plan.planId.toString() },
+  });
+};
+
+// 이벤트 핸들러
+const handlePlanLikeClick = (plan: Plan) => {
+  console.log('여행 계획 좋아요 클릭:', plan.title);
+};
+
+const handlePlanTagClick = (tag: Tag) => {
+  console.log('여행 계획 태그 클릭:', tag.name);
+};
+</script>

--- a/front_end/src/views/PlanDetail.vue
+++ b/front_end/src/views/PlanDetail.vue
@@ -1,0 +1,66 @@
+<template>
+  <div class="h-full overflow-y-auto">
+    <div class="flex items-center border-b border-white/20 bg-slate-900/80 p-2">
+      <Button
+        variant="ghost"
+        size="icon"
+        class="mr-2 h-8 w-8 text-gray-300 hover:bg-white/10 hover:text-white"
+        @click="goBack"
+      >
+        <ChevronLeft class="h-5 w-5" />
+      </Button>
+      <h3 class="text-lg font-semibold text-white">여행 계획 상세</h3>
+    </div>
+
+    <AsyncContainer :loadingComponent="PlanDetailSkeleton" :errorComponent="PlanDetailError">
+      <PlanDetail :planId="planId" @toggleLike="handleToggleLike" />
+    </AsyncContainer>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, watch } from 'vue';
+import { useRouter, useRoute } from 'vue-router';
+import { ChevronLeft } from 'lucide-vue-next';
+import AsyncContainer from '@/components/AsyncContainer/AsyncContainer.vue';
+import { Button } from '@/components/ui/button';
+import {
+  PlanDetailError,
+  PlanDetailSkeleton,
+  PlanDetail,
+} from '@/components/views/plan/PlanDetail';
+import { useMapState } from '@/composables/useMapState';
+import { ROUTES } from '@/router/routes';
+
+// Vue Router
+const router = useRouter();
+const route = useRoute();
+
+// planId 계산 속성
+const planId = computed(() => route.params.planId as string);
+
+// 지도 상태 관리
+const { mapRef, showAllMarkers } = useMapState();
+
+// MapContainer 컴포넌트의 map 객체 감시
+// 여기가 핵심: mapRef.value.map이 변경될 때마다 마커를 다시 그림
+watch(
+  () => mapRef.value?.map,
+  newMap => {
+    if (newMap) {
+      showAllMarkers();
+    }
+  },
+  { deep: true }
+);
+
+// 좋아요 토글 핸들러
+const handleToggleLike = (planId: number) => {
+  console.log('여행 계획 좋아요 토글:', planId);
+};
+
+// 뒤로 가기
+const goBack = () => {
+  router.push({ name: ROUTES.PLANS.name });
+};
+</script>


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #55 

## 📝 작업 내용
- [x] 여행 계획 페이지 중첩 라우팅 설정
- [x] 여행 계획 필터링 조회
- [x] 필터링 컴포넌트
- [x] 지도에 여행 계획 전체 여행지 표시
- [x] 일별 여행 계획 경로 표시

## 📑 작업 상세 내용
- useMapState 싱글톤 훅으로 변경
- 일단 기능 구현을 우선적으로 코드, 스타일 리팩토링 필요

|뷰|
|--|
|여행 계획 목록|
|![image](https://github.com/user-attachments/assets/a158e9ba-0c39-4874-9aa1-08522efd050b)|
|여행 계획 상세|
|![image](https://github.com/user-attachments/assets/ce76e823-6b0c-4c73-8918-700a1de994ef)|

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 여행 계획 목록 및 상세 페이지가 추가되었습니다.
  - 여행 계획 필터, 목록, 상세, 일정, 정보, 에러 및 스켈레톤 컴포넌트가 도입되었습니다.
  - 여행 계획 상세에서 일정별 명소와 경로 시각화, 별자리 헤더, 좋아요 기능이 제공됩니다.
  - 지도에서 여행 계획 경로 및 명소 마커가 표시됩니다.
  - 여행 계획 필터링 UI 및 관련 상태 관리용 컴포저블이 추가되었습니다.
  - 여행 계획 상세 조회 API가 추가되었습니다.
  - 내비게이션 바의 '여행계획' 메뉴 경로가 '/plans'로 변경되었습니다.

- **버그 수정**
  - 명소 목록의 에러 컴포넌트가 올바르게 교체되었습니다.

- **스타일**
  - 버튼에 hover 시 커서 포인터 스타일이 추가되었습니다.

- **문서화**
  - 타입 및 API 서비스가 여행 계획 상세 데이터 구조를 반영하도록 확장되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->