### PR TITLE
[FE-FEAT] 헤더 네이게이션 바 완성

### DIFF
--- a/front_end/package-lock.json
+++ b/front_end/package-lock.json
@@ -26,6 +26,7 @@
         "vite-plugin-vue-devtools": "^7.7.6",
         "vue": "^3.5.13",
         "vue-router": "^4.5.1",
+        "vue-sonner": "^1.3.2",
         "zod": "^3.24.4"
       },
       "devDependencies": {
@@ -9300,6 +9301,12 @@
       "peerDependencies": {
         "vue": "^3.2.0"
       }
+    },
+    "node_modules/vue-sonner": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/vue-sonner/-/vue-sonner-1.3.2.tgz",
+      "integrity": "sha512-UbZ48E9VIya3ToiRHAZUbodKute/z/M1iT8/3fU8zEbwBRE11AKuHikssv18LMk2gTTr6eMQT4qf6JoLHWuj/A==",
+      "license": "MIT"
     },
     "node_modules/vue-tsc": {
       "version": "2.2.10",

--- a/front_end/package.json
+++ b/front_end/package.json
@@ -31,6 +31,7 @@
     "vite-plugin-vue-devtools": "^7.7.6",
     "vue": "^3.5.13",
     "vue-router": "^4.5.1",
+    "vue-sonner": "^1.3.2",
     "zod": "^3.24.4"
   },
   "devDependencies": {

--- a/front_end/src/components/Modal/content/SignupForm.vue
+++ b/front_end/src/components/Modal/content/SignupForm.vue
@@ -2,23 +2,29 @@
 import { ref } from 'vue';
 import { Button } from '@/components/ui/button';
 import { FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
-import { Mail, Lock, LogIn, UserPlus } from 'lucide-vue-next';
+import { Mail, Lock, User, UserPlus, ArrowLeft } from 'lucide-vue-next';
 import { useForm } from 'vee-validate';
 import { z } from 'zod';
 import { toTypedSchema } from '@vee-validate/zod';
-import { login } from '@/services/api/domains/auth/index';
-import { useAuthStore } from '@/stores/auth';
+import { signup } from '@/services/api/domains/auth/index';
 import { toast } from 'vue-sonner';
 
 // 폼 스키마 정의
 const formSchema = toTypedSchema(
-  z.object({
-    email: z
-      .string()
-      .min(1, { message: '이메일을 입력해주세요.' })
-      .email({ message: '유효한 이메일 주소를 입력해주세요.' }),
-    password: z.string().min(1, { message: '비밀번호를 입력해주세요.' }),
-  })
+  z
+    .object({
+      email: z
+        .string()
+        .min(1, { message: '이메일을 입력해주세요.' })
+        .email({ message: '유효한 이메일 주소를 입력해주세요.' }),
+      name: z.string().min(1, { message: '이름을 입력해주세요.' }),
+      password: z.string().min(8, { message: '비밀번호는 8자 이상이어야 합니다.' }),
+      confirmPassword: z.string().min(1, { message: '비밀번호를 다시 입력해주세요.' }),
+    })
+    .refine(data => data.password === data.confirmPassword, {
+      message: '비밀번호가 일치하지 않습니다.',
+      path: ['confirmPassword'],
+    })
 );
 
 const isLoading = ref(false);
@@ -28,38 +34,32 @@ const form = useForm({
   validationSchema: formSchema,
   initialValues: {
     email: '',
+    name: '',
     password: '',
+    confirmPassword: '',
   },
 });
 
 const emit = defineEmits<{
   (e: 'close'): [];
-  (e: 'toSignup'): [];
+  (e: 'toLogin'): [];
 }>();
 
 // 폼 제출 핸들러
 const onSubmit = form.handleSubmit(async values => {
   isLoading.value = true;
   try {
-    // API 호출 구현 예정
-    // await new Promise(resolve => setTimeout(resolve, 800));
-    login(values).then(
-      res => {
-        useAuthStore().setAuth(
-          {
-            id: res.id,
-            email: res.email,
-            name: res.name,
-          },
-          {
-            accessToken: res.accessToken,
-            refreshToken: res.refreshToken,
-          }
-        );
-        emit('close');
+    // signup API 호출
+    const { email, name, password } = values;
+    const signupData = { email, name, password };
+
+    await signup(signupData).then(
+      () => {
+        toast('회원가입이 완료되었습니다. 로그인해주세요.');
+        emit('toLogin');
       },
       error => {
-        toast(error.response.data.body.message);
+        toast(error.response?.data?.body?.message || '회원가입 중 오류가 발생했습니다.');
       }
     );
   } finally {
@@ -67,15 +67,15 @@ const onSubmit = form.handleSubmit(async values => {
   }
 });
 
-// Register redirect
-const handleRegister = () => {
-  emit('toSignup');
+// 로그인 페이지로 이동
+const handleLogin = () => {
+  emit('toLogin');
 };
 </script>
 
 <template>
   <div class="relative z-10 space-y-4">
-    <h2 class="mb-6 text-center text-2xl font-bold text-white">로그인</h2>
+    <h2 class="mb-6 text-center text-2xl font-bold text-white">회원가입</h2>
 
     <form class="space-y-4" @submit="onSubmit">
       <!-- Email Input -->
@@ -93,6 +93,30 @@ const handleRegister = () => {
                 class="block w-full rounded-lg border border-purple-500/30 bg-indigo-900/50 p-2.5 pl-10 text-sm text-white focus:border-purple-500 focus:ring-purple-500"
                 placeholder="name@stellatrip.com"
                 type="email"
+                @input="handleChange"
+                @blur="handleBlur"
+              />
+            </FormControl>
+          </div>
+          <FormMessage class="text-red-400" />
+        </FormItem>
+      </FormField>
+
+      <!-- Name Input -->
+      <FormField v-slot="{ componentField, handleBlur, handleChange, value }" name="name">
+        <FormItem>
+          <FormLabel class="text-white">이름</FormLabel>
+          <div class="relative">
+            <div class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
+              <User class="h-5 w-5 text-purple-400" />
+            </div>
+            <FormControl>
+              <input
+                v-bind="componentField"
+                :value="value"
+                class="block w-full rounded-lg border border-purple-500/30 bg-indigo-900/50 p-2.5 pl-10 text-sm text-white focus:border-purple-500 focus:ring-purple-500"
+                placeholder="사용자 이름"
+                type="text"
                 @input="handleChange"
                 @blur="handleBlur"
               />
@@ -125,31 +149,57 @@ const handleRegister = () => {
           <FormMessage class="text-red-400" />
         </FormItem>
       </FormField>
+      <!-- Confirm Password Input -->
+      <FormField
+        v-slot="{ componentField, handleBlur, handleChange, value }"
+        name="confirmPassword"
+      >
+        <FormItem>
+          <FormLabel class="text-white">비밀번호 확인</FormLabel>
+          <div class="relative">
+            <div class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
+              <Lock class="h-5 w-5 text-purple-400" />
+            </div>
+            <FormControl>
+              <input
+                v-bind="componentField"
+                :value="value"
+                class="block w-full rounded-lg border border-purple-500/30 bg-indigo-900/50 p-2.5 pl-10 text-sm text-white focus:border-purple-500 focus:ring-purple-500"
+                placeholder="••••••••"
+                type="password"
+                @input="handleChange"
+                @blur="handleBlur"
+              />
+            </FormControl>
+          </div>
+          <FormMessage class="text-red-400" />
+        </FormItem>
+      </FormField>
 
-      <!-- Login Button -->
+      <!-- Signup Button -->
       <Button
         type="submit"
         class="flex w-full items-center justify-center gap-2 bg-purple-600 hover:bg-purple-700"
         :disabled="isLoading"
       >
-        <LogIn v-if="!isLoading" class="h-4 w-4" />
+        <UserPlus v-if="!isLoading" class="h-4 w-4" />
         <span
           v-if="isLoading"
           class="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent"
         ></span>
-        {{ isLoading ? '로그인 중...' : '로그인' }}
+        {{ isLoading ? '가입 중...' : '회원가입' }}
       </Button>
 
-      <!-- Register Link -->
+      <!-- Login Link -->
       <div class="mt-4 text-center">
         <p class="text-sm text-gray-300">
-          계정이 없으신가요?
+          이미 계정이 있으신가요?
           <a
             class="inline-flex cursor-pointer items-center gap-1 text-purple-400 hover:text-purple-300"
-            @click="handleRegister"
+            @click="handleLogin"
           >
-            회원가입
-            <UserPlus class="h-3 w-3" />
+            로그인
+            <ArrowLeft class="h-3 w-3" />
           </a>
         </p>
       </div>

--- a/front_end/src/components/NavigationBar/NavigationBar.vue
+++ b/front_end/src/components/NavigationBar/NavigationBar.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, reactive } from 'vue';
+import { ROUTES } from '@/router/routes';
 import { useRouter } from 'vue-router';
 import { Button } from '@/components/ui/button';
 import {
@@ -56,7 +57,7 @@ const isLoggedIn = computed(() => {
 const menuItems = computed(() => {
   const navigationItems = [
     { name: '여행계획', icon: Map, route: '/trip-plans' },
-    { name: '여행지', icon: Compass, route: '/attractions' },
+    { name: '여행지', icon: Compass, route: ROUTES.ATTRACTION.path },
   ];
 
   return navigationItems;
@@ -74,13 +75,13 @@ const handleLogout = () => {
   const authStore = useAuthStore();
   logout({ refreshToken: authStore.getRefreshToken == null ? '' : authStore.getRefreshToken })
     .then(() => {
-      authStore.clearAuth();
       toast('로그아웃 되었습니다.');
     })
     .catch(() => {
       // Handle error during logout
       toast('로그아웃중 오류가 발생했습니다.');
     });
+  authStore.clearAuth();
 };
 
 const handleModalClose = () => {

--- a/front_end/src/components/ui/sonner/Sonner.vue
+++ b/front_end/src/components/ui/sonner/Sonner.vue
@@ -1,0 +1,18 @@
+<script lang="ts" setup>
+import { Toaster as Sonner, type ToasterProps } from 'vue-sonner'
+
+const props = defineProps<ToasterProps>()
+</script>
+
+<template>
+  <Sonner
+    class="toaster group"
+    v-bind="props"
+    :style="{
+      '--normal-bg': 'var(--popover)',
+      '--normal-text': 'var(--popover-foreground)',
+      '--normal-border': 'var(--border)',
+
+    }"
+  />
+</template>

--- a/front_end/src/components/ui/sonner/index.ts
+++ b/front_end/src/components/ui/sonner/index.ts
@@ -1,0 +1,1 @@
+export { default as Toaster } from './Sonner.vue'

--- a/front_end/src/services/api/domains/auth/index.ts
+++ b/front_end/src/services/api/domains/auth/index.ts
@@ -8,6 +8,7 @@ import type {
   LogoutResponse,
   SignoutResponse,
   SignupResponse,
+  LogoutRequest,
 } from './types';
 
 /**
@@ -24,8 +25,8 @@ export const login = async (data: LoginRequest): Promise<LoginResponse> => {
  * 사용자 로그아웃
  * @returns 로그아웃 성공 여부
  */
-export const logout = async (): Promise<LogoutResponse> => {
-  const response = await api.post<ApiResponse<LogoutResponse>>(AUTH.LOGOUT);
+export const logout = async (data: LogoutRequest): Promise<LogoutResponse> => {
+  const response = await api.post<ApiResponse<LogoutResponse>>(AUTH.LOGOUT, data);
   return response.data.body;
 };
 

--- a/front_end/src/services/api/domains/auth/types.ts
+++ b/front_end/src/services/api/domains/auth/types.ts
@@ -5,6 +5,10 @@ export type LoginRequest = {
   password: string;
 };
 
+export type LogoutRequest = {
+  refreshToken: string;
+};
+
 export type LoginResponse = User & AuthToken;
 
 export type SignupRequest = {

--- a/front_end/src/services/api/interceptors.ts
+++ b/front_end/src/services/api/interceptors.ts
@@ -21,7 +21,7 @@ export const setupInterceptors = (api: AxiosInstance): void => {
       const token = authStore.getAccessToken;
 
       if (token) {
-        config.headers.Authorization = `Bearer ${token}`;
+        config.headers.Authorization = `${token}`;
       }
 
       return config;

--- a/front_end/src/types/type.ts
+++ b/front_end/src/types/type.ts
@@ -3,7 +3,7 @@ import type { AttractionContentType } from '@/constants/constant';
 export type User = {
   id: string;
   email: string;
-  username: string;
+  name: string;
 };
 
 export type AuthToken = {


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- 

## 📝 작업 내용
- [x] 헤더 로그아웃 추가
- [x] 헤더 회원가입 폼 추라
- [x] 회원가입 api 호출 추가

## 📑 작업 상세 내용


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 회원가입 폼이 추가되어 사용자가 직접 회원가입을 할 수 있습니다.
  - 로그인 및 회원가입이 모달 내에서 전환 가능하도록 개선되었습니다.
  - 토스트 알림 기능이 도입되어 로그인, 로그아웃, 회원가입 등 주요 작업 시 알림이 표시됩니다.
  - 로그아웃 API 호출 시 토큰을 포함하도록 변경되어 보안이 강화되었습니다.

- **버그 수정**
  - 로그인 실패 시 서버에서 받은 오류 메시지가 토스트로 안내됩니다.

- **UI/UX 개선**
  - 네비게이션 바에서 로그인/회원가입이 버튼으로 변경되어 더 직관적으로 이용할 수 있습니다.
  - 로그아웃 시 토스트 알림이 제공되며, 인증 정보가 안전하게 초기화됩니다.

- **기타**
  - 사용자 정보 구조에서 username이 name으로 변경되었습니다.
  - 인증 토큰 전송 방식에서 "Bearer " 접두어가 제거되어 API 요청 방식이 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->