### PR TITLE
[BE-FEAT] 여행지 api 수정사항

### DIFF
--- a/back_end/src/main/java/com/ssafy/stella_trip/attraction/controller/AttractionController.java
+++ b/back_end/src/main/java/com/ssafy/stella_trip/attraction/controller/AttractionController.java
@@ -17,6 +17,8 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/v1/attractions")
 @PreAuthorize("isAuthenticated()")
@@ -39,13 +41,13 @@ public class AttractionController {
     public CommonResponse<PageDTO<AttractionResponseDTO>> getAttractions(
             @RequestParam(value = "page", defaultValue = "1") int page,
             @RequestParam(value = "size", defaultValue = "20") int size,
-            @RequestParam(value = "sidoCode", defaultValue = "") Integer sidoCode,
-            @RequestParam(value = "gugunCode", defaultValue = "") Integer gugunCode,
-            @RequestParam(value = "contentTypeId", defaultValue = "") Integer contentTypeId,
+            @RequestParam(value = "sidoCode", required = false) Integer sidoCode,
+            @RequestParam(value = "gugunCode", required = false) Integer gugunCode,
+            @RequestParam(value = "contentTypeIds", required = false) List<Integer> contentTypeIds,
             @RequestParam(value = "keyword", defaultValue = "") String keyword,
             @AuthenticationPrincipal JwtUserInfo user
     ) {
-        return new CommonResponse<>(attractionService.getAttractionsByCondition(sidoCode, gugunCode, contentTypeId, keyword, page, size, user), HttpStatus.OK);
+        return new CommonResponse<>(attractionService.getAttractionsByCondition(sidoCode, gugunCode, contentTypeIds, keyword, page, size, user), HttpStatus.OK);
     }
 
     @GetMapping("/{attractionId}")

--- a/back_end/src/main/java/com/ssafy/stella_trip/attraction/dto/ReviewDTO.java
+++ b/back_end/src/main/java/com/ssafy/stella_trip/attraction/dto/ReviewDTO.java
@@ -1,5 +1,6 @@
 package com.ssafy.stella_trip.attraction.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -23,5 +24,6 @@ public class ReviewDTO {
     private LocalDate visitDate;
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
+    @JsonProperty("isLiked")
     private boolean isLiked;
 }

--- a/back_end/src/main/java/com/ssafy/stella_trip/attraction/dto/request/ReviewRequestDTO.java
+++ b/back_end/src/main/java/com/ssafy/stella_trip/attraction/dto/request/ReviewRequestDTO.java
@@ -1,6 +1,5 @@
 package com.ssafy.stella_trip.attraction.dto.request;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 
 import java.time.LocalDate;
@@ -14,6 +13,5 @@ public class ReviewRequestDTO {
     private String title;
     private String content;
     private double rating;
-    @JsonProperty("visit_date")
     private LocalDate visitDate;
 }

--- a/back_end/src/main/java/com/ssafy/stella_trip/attraction/dto/response/AttractionResponseDTO.java
+++ b/back_end/src/main/java/com/ssafy/stella_trip/attraction/dto/response/AttractionResponseDTO.java
@@ -22,6 +22,7 @@ public class AttractionResponseDTO {
     private double rating;
     private double latitude;
     private double longitude;
+    @JsonProperty("isLiked")
     private boolean isLiked;
     private List<ReviewResponseDTO> review;
 }

--- a/back_end/src/main/java/com/ssafy/stella_trip/attraction/dto/response/ReviewResponseDTO.java
+++ b/back_end/src/main/java/com/ssafy/stella_trip/attraction/dto/response/ReviewResponseDTO.java
@@ -14,18 +14,15 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ReviewResponseDTO {
-    @JsonProperty("review_id")
     private int reviewId;
-    @JsonProperty("user_id")
     private int userId;
-    @JsonProperty("user_name")
     private String userName;
     private String title;
     private String content;
     private double rating;
-    @JsonProperty("visit_date")
     private LocalDate visitDate;
-    @JsonProperty("created_at")
     private LocalDateTime createdAt;
+    private int likeCount;
+    @JsonProperty("isLiked")
     private boolean isLiked;
 }

--- a/back_end/src/main/java/com/ssafy/stella_trip/attraction/service/AttractionService.java
+++ b/back_end/src/main/java/com/ssafy/stella_trip/attraction/service/AttractionService.java
@@ -271,6 +271,7 @@ public class AttractionService {
                 .content(review.getContent())
                 .rating(review.getRating())
                 .visitDate(review.getVisitDate())
+                .likeCount(review.getLikeCount())
                 .createdAt(review.getCreatedAt())
                 .isLiked(review.isLiked())
                 .build();

--- a/back_end/src/main/java/com/ssafy/stella_trip/attraction/service/AttractionService.java
+++ b/back_end/src/main/java/com/ssafy/stella_trip/attraction/service/AttractionService.java
@@ -17,16 +17,19 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class AttractionService {
 
     private final AttractionDAO attractionDAO;
 
+    @Transactional
     public PageDTO<AttractionResponseDTO> getAttractionsByCondition(
             Integer sidoCode,
             Integer gugunCode,
-            Integer contentTypeId,
+            List<Integer> contentTypeIds,
             String keyword,
             int page,
             int size,
@@ -36,12 +39,12 @@ public class AttractionService {
         return PaginationUtils.getPagedResult(
                 page,
                 size,
-                () -> attractionDAO.getAttractionCountByConditions(sidoCode, gugunCode, contentTypeId, keyword),
+                () -> attractionDAO.getAttractionCountByConditions(sidoCode, gugunCode, contentTypeIds, keyword),
                 (offset, pageSize) -> attractionDAO.getAttractionByConditions(
                         userId,
                         sidoCode,
                         gugunCode,
-                        contentTypeId,
+                        contentTypeIds,
                         keyword,
                         offset,
                         pageSize

--- a/back_end/src/main/java/com/ssafy/stella_trip/dao/attraction/AttractionDAO.java
+++ b/back_end/src/main/java/com/ssafy/stella_trip/dao/attraction/AttractionDAO.java
@@ -18,7 +18,7 @@ public interface AttractionDAO {
             @Param("userId") int userId,
             @Param("sidoCode") Integer sidoCode,
             @Param("gugunCode") Integer gugunCode,
-            @Param("contentTypeId") Integer contentTypeId,
+            @Param("contentTypeIds") List<Integer> contentTypeIds,
             @Param("keyword") String keyword,
             @Param("offset") int offset,
             @Param("size") int size);
@@ -26,7 +26,7 @@ public interface AttractionDAO {
     int getAttractionCountByConditions(
             @Param("sidoCode") Integer sidoCode,
             @Param("gugunCode") Integer gugunCode,
-            @Param("contentTypeId") Integer contentTypeId,
+            @Param("contentTypeIds") List<Integer> contentTypeIds,
             @Param("keyword") String keyword);
 
     List<AttractionDTO> getAttractionsByContentTypeId(int contentTypeId);

--- a/back_end/src/main/resources/mappers/Attraction.xml
+++ b/back_end/src/main/resources/mappers/Attraction.xml
@@ -151,8 +151,11 @@
                     AND a.gugun_code = #{gugunCode}
                 </if>
             </if>
-            <if test="contentTypeId != null">
-                AND a.content_type_id = #{contentTypeId}
+            <if test="contentTypeIds != null and !contentTypeIds.isEmpty()">
+                AND a.content_type_id IN
+                <foreach collection="contentTypeIds" item="contentTypeId" open="(" close=")" separator=",">
+                    #{contentTypeId}
+                </foreach>
             </if>
             <if test="keyword != null">
                 AND a.title LIKE CONCAT('%', #{keyword}, '%')
@@ -171,8 +174,11 @@
                     AND a.gugun_code = #{gugunCode}
                 </if>
             </if>
-            <if test="contentTypeId != null">
-                AND a.content_type_id = #{contentTypeId}
+            <if test="contentTypeIds != null and !contentTypeIds.isEmpty()">
+                AND a.content_type_id IN
+                <foreach collection="contentTypeIds" item="contentTypeId" open="(" close=")" separator=",">
+                    #{contentTypeId}
+                </foreach>
             </if>
             <if test="keyword != null">
                 AND a.title LIKE CONCAT('%', #{keyword}, '%')

--- a/back_end/src/main/resources/mappers/Attraction.xml
+++ b/back_end/src/main/resources/mappers/Attraction.xml
@@ -136,14 +136,9 @@
         WHEN fa.user_id IS NOT NULL THEN 1
         ELSE 0
         END AS is_liked
+        FROM (
+        SELECT a.*
         FROM attraction a
-        LEFT JOIN liked_attraction fa ON a.attraction_id = fa.attraction_id AND fa.user_id = #{userId}
-        LEFT JOIN (
-        SELECT r1.*,
-        ROW_NUMBER() OVER (PARTITION BY r1.attraction_id ORDER BY r1.rating DESC, r1.created_at DESC) as row_num
-        FROM review r1
-        ) r ON a.attraction_id = r.attraction_id AND r.row_num &lt;= 2
-        LEFT JOIN user u ON r.user_id = u.user_id
         <where>
             <if test="sidoCode != null">
                 AND a.sido_code = #{sidoCode}
@@ -162,6 +157,15 @@
             </if>
         </where>
         LIMIT #{size} OFFSET #{offset}
+        ) a
+        LEFT JOIN liked_attraction fa ON a.attraction_id = fa.attraction_id AND fa.user_id = #{userId}
+        LEFT JOIN (
+        SELECT r1.*,
+        ROW_NUMBER() OVER (PARTITION BY r1.attraction_id ORDER BY r1.rating DESC, r1.created_at DESC) as row_num
+        FROM review r1
+        ) r ON a.attraction_id = r.attraction_id AND r.row_num &lt; 2
+        LEFT JOIN user u ON r.user_id = u.user_id
+        ORDER BY a.attraction_id, r.row_num
     </select>
 
     <select id="getAttractionCountByConditions" resultType="int">


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #42 
- #53 

## 📝 작업 내용
- [x] content type 필터링 태그 여러개 적용
- [x] isLiked필드 is 포함
- [x] 여행지 목록 쿼리문 수정

## 📑 작업 상세 내용


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 여러 개의 콘텐츠 유형 ID로 관광지 목록을 필터링할 수 있도록 기능이 확장되었습니다.

- **버그 수정**
    - 관광지 및 리뷰 응답에서 isLiked 필드의 JSON 속성명이 일관되게 "isLiked"로 표시됩니다.
    - 리뷰 응답에 좋아요 개수(likeCount)와 좋아요 여부(isLiked) 정보가 추가되었습니다.
    - 일부 필드의 JSON 속성명이 기본값으로 변경되어 직렬화/역직렬화가 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->