### PR TITLE
[BE-FEAT] 내 여행계획 조회 추가

### DIFF
--- a/back_end/src/main/java/com/ssafy/stella_trip/dao/plan/PlanDAO.java
+++ b/back_end/src/main/java/com/ssafy/stella_trip/dao/plan/PlanDAO.java
@@ -116,4 +116,12 @@ public interface PlanDAO {
     List<PlanDTO> getLikedPlansByUserId(@Param("userId") int userId, @Param("offset") int offset, @Param("size") int size);
 
     List<TagDTO> getTagsOrderedByCount(int size);
+
+    int countPlansByWriterId(@Param("userId") int userId);
+
+    List<PlanDTO> getPlansByWriterId(
+            @Param("userId") int userId,
+            @Param("offset") int offset,
+            @Param("size") int size
+    );
 }

--- a/back_end/src/main/java/com/ssafy/stella_trip/plan/controller/PlanController.java
+++ b/back_end/src/main/java/com/ssafy/stella_trip/plan/controller/PlanController.java
@@ -318,4 +318,17 @@ public class PlanController {
     ) {
         return new CommonResponse<>(planService.getPopularTags(size), HttpStatus.OK);
     }
+
+    @GetMapping("/myPlans")
+    @Operation(
+            summary = "내 여행 계획 목록 조회"
+    )
+    public CommonResponse<PageDTO<PlanResponseDTO>> getMyPlans(
+            @RequestParam(value = "page", defaultValue = "1") int page,
+            @RequestParam(value = "size", defaultValue = "20") int size,
+            @AuthenticationPrincipal JwtUserInfo user
+    ) {
+        return new CommonResponse<>(planService.getMyPlans(page, size, user), HttpStatus.OK);
+    }
+
 }

--- a/back_end/src/main/java/com/ssafy/stella_trip/plan/service/PlanService.java
+++ b/back_end/src/main/java/com/ssafy/stella_trip/plan/service/PlanService.java
@@ -429,6 +429,9 @@ public class PlanService {
     }
 
     public PageDTO<PlanResponseDTO> getMyPlans(int page, int size, JwtUserInfo user) {
+        if (size < 1) {
+            size = 20;
+        }
         return PaginationUtils.getPagedResult(
                 page,
                 size,

--- a/back_end/src/main/java/com/ssafy/stella_trip/plan/service/PlanService.java
+++ b/back_end/src/main/java/com/ssafy/stella_trip/plan/service/PlanService.java
@@ -428,6 +428,38 @@ public class PlanService {
         return convertRouteToResponse(planDAO.getRouteByRouteId(routeId));
     }
 
+    public PageDTO<PlanResponseDTO> getMyPlans(int page, int size, JwtUserInfo user) {
+        return PaginationUtils.getPagedResult(
+                page,
+                size,
+                () -> planDAO.countPlansByWriterId(user.getUserId()),
+                (offset, pageSize) -> planDAO.getPlansByWriterId(user.getUserId(), offset, pageSize),
+                this::convertPlanDTOtoPlanResponseDTO);
+    }
+
+    private PlanResponseDTO convertPlanDTOtoPlanResponseDTO(PlanDTO planDTO) {
+        // 태그 리스트
+        List<TagResponseDTO> tagResponseDTOList = convertTagsToResponse(planDTO.getTags());
+
+        // 작성자 리스트
+        List<WriterResponseDTO> writerResponseDTOList = convertWritersToResponse(planDTO.getWriters());
+
+        // PlanResponseDTO 생성
+        return PlanResponseDTO.builder()
+                .planId(planDTO.getPlanId())
+                .title(planDTO.getTitle())
+                .description(planDTO.getDescription())
+                .stella(planDTO.getStella())
+                .startDate(planDTO.getStartDate())
+                .endDate(planDTO.getEndDate())
+                .likeCount(planDTO.getLikeCount())
+                .isPublic(planDTO.isPublic())
+                .planWriters(writerResponseDTOList)
+                .tags(tagResponseDTOList)
+                .liked(planDTO.isLiked())
+                .build();
+    }
+
     private void checkPlanAuthority(int planId, JwtUserInfo user) throws PlanNotFoundException, UnauthorizedPlanAccessException{
         if(user == null) {
             throw new UnauthorizedPlanAccessException("로그인이 필요합니다.");

--- a/back_end/src/main/java/com/ssafy/stella_trip/stella/controller/StellaController.java
+++ b/back_end/src/main/java/com/ssafy/stella_trip/stella/controller/StellaController.java
@@ -13,7 +13,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
-@Controller
+@RestController
 @RequiredArgsConstructor
 @RequestMapping("v1/stella")
 public class StellaController {

--- a/back_end/src/main/java/com/ssafy/stella_trip/stella/dto/StellaDTO.java
+++ b/back_end/src/main/java/com/ssafy/stella_trip/stella/dto/StellaDTO.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class StellaDTO {
-    private int StellaLinkId;
+    private int stellaLinkId;
     private int planId;
     private String stellaData;
     private String stellaLink;

--- a/back_end/src/main/resources/mappers/Plan.xml
+++ b/back_end/src/main/resources/mappers/Plan.xml
@@ -172,6 +172,8 @@
         FROM plan_writer pw2
         WHERE pw2.plan_id = p.plan_id AND pw2.user_id = #{userId}
         )
+        ORDER BY p.created_at DESC
+        LIMIT #{size} OFFSET #{offset}
     </select>
 
     <!-- 검색 조건에 맞는 여행 계획 목록 조회 -->

--- a/back_end/src/main/resources/mappers/Plan.xml
+++ b/back_end/src/main/resources/mappers/Plan.xml
@@ -145,6 +145,35 @@
         WHERE r.plan_id = #{planId}
     </select>
 
+    <select id = "countPlansByWriterId" resultType="int">
+        SELECT COUNT(DISTINCT p.plan_id)
+        FROM plan p
+        JOIN plan_writer pw ON p.plan_id = pw.plan_id
+        WHERE pw.user_id = #{userId}
+    </select>
+
+    <select id="getPlansByWriterId" resultMap="PlanMap">
+        SELECT
+        p.*,
+        u.user_id, u.name as user_name, u.email, u.role, u.description, u.image, u.created_at, u.modified_at,
+        t.tag_id, t.name as tag_name,
+        CASE
+        WHEN pl.user_id IS NOT NULL THEN 1
+        ELSE 0
+        END AS liked
+        FROM plan p
+        LEFT JOIN plan_writer pw ON p.plan_id = pw.plan_id
+        LEFT JOIN user u ON pw.user_id = u.user_id
+        LEFT JOIN tag_plan tp ON p.plan_id = tp.plan_id
+        LEFT JOIN tag t ON tp.tag_id = t.tag_id
+        LEFT JOIN liked_plan pl ON p.plan_id = pl.plan_id AND pl.user_id = #{userId}
+        WHERE EXISTS (
+        SELECT 1
+        FROM plan_writer pw2
+        WHERE pw2.plan_id = p.plan_id AND pw2.user_id = #{userId}
+        )
+    </select>
+
     <!-- 검색 조건에 맞는 여행 계획 목록 조회 -->
     <select id="getPlansByCondition" resultMap="PlanMap">
         SELECT

--- a/back_end/src/main/resources/mappers/Stella.xml
+++ b/back_end/src/main/resources/mappers/Stella.xml
@@ -4,7 +4,7 @@
         "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.ssafy.stella_trip.dao.stella.StellaDAO">
     <resultMap id="StellaResultMap" type="StellaDTO">
-        <id property="StellaLinkId" column="stella_link_id"/>
+        <id property="stellaLinkId" column="stella_link_id"/>
         <result property="planId" column="plan_id"/>
         <result property="stellaData" column="stella_data"/>
         <result property="stellaLink" column="stella_link"/>


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- 

## 📝 작업 내용
- [ ] 내 여행계획 조회 추가

## 📑 작업 상세 내용


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 사용자가 자신의 여행 계획 목록을 조회할 수 있는 새로운 API 엔드포인트가 추가되었습니다. (페이지네이션 지원)
  - 여행 계획 작성자별 계획 수와 목록을 조회하는 기능이 추가되었습니다.

- **버그 수정**
  - Stella 관련 데이터의 필드명 및 매핑명이 일관된 소문자(camelCase)로 정정되었습니다.

- **문서화**
  - 여행 계획 목록 조회 API에 대한 OpenAPI 문서가 추가되었습니다.

- **스타일**
  - 컨트롤러 클래스의 어노테이션이 일관성 있게 수정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->