### PR TITLE
[FE-FEAT] 여행 계획 수정 화면 뷰 + api

### DIFF
--- a/front_end/package-lock.json
+++ b/front_end/package-lock.json
@@ -28,6 +28,7 @@
         "vue": "^3.5.13",
         "vue-router": "^4.5.1",
         "vue-sonner": "^1.3.2",
+        "vuedraggable": "^4.1.0",
         "zod": "^3.24.4"
       },
       "devDependencies": {
@@ -8380,6 +8381,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/sortablejs": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.14.0.tgz",
+      "integrity": "sha512-pBXvQCs5/33fdN1/39pPL0NZF20LeRbLQ5jtnheIPN9JQAaufGjKdWduZn4U7wCtVuzKhmRkI0DFYHYRbB2H1w==",
+      "license": "MIT"
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -9815,6 +9822,18 @@
       },
       "peerDependencies": {
         "typescript": ">=5.0.0"
+      }
+    },
+    "node_modules/vuedraggable": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/vuedraggable/-/vuedraggable-4.1.0.tgz",
+      "integrity": "sha512-FU5HCWBmsf20GpP3eudURW3WdWTKIbEIQxh9/8GE806hydR9qZqRRxRE3RjqX7PkuLuMQG/A7n3cfj9rCEchww==",
+      "license": "MIT",
+      "dependencies": {
+        "sortablejs": "1.14.0"
+      },
+      "peerDependencies": {
+        "vue": "^3.0.1"
       }
     },
     "node_modules/webpack-virtual-modules": {

--- a/front_end/package.json
+++ b/front_end/package.json
@@ -33,6 +33,7 @@
     "vue": "^3.5.13",
     "vue-router": "^4.5.1",
     "vue-sonner": "^1.3.2",
+    "vuedraggable": "^4.1.0",
     "zod": "^3.24.4"
   },
   "devDependencies": {

--- a/front_end/src/components/card/DailyScheduleCard/DailyScheduleCard.vue
+++ b/front_end/src/components/card/DailyScheduleCard/DailyScheduleCard.vue
@@ -9,18 +9,44 @@
         {{ date }}
       </h4>
     </CardHeader>
-    <CardContent class="flex flex-col gap-2 px-3">
-      <AttractionItem
-        v-for="attraction in sortedAttractions"
-        :key="attraction.routeId"
-        :order="attraction.order"
-        :name="attraction.name"
-        :visitTime="attraction.visitTime"
-        :address="attraction.address"
-        :memo="attraction.memo ?? ''"
-      />
+    <CardContent class="px-3">
+      <!-- Vue Draggable 컨테이너 -->
+      <draggable
+        v-model="localAttractions"
+        :itemKey="`${props.date}`"
+        :disabled="!planStore.isModifying"
+        class="flex flex-col gap-2"
+        :animation="150"
+        ghostClass="sortable-ghost"
+        chosenClass="sortable-chosen"
+        dragClass="sortable-drag"
+        @end="handleOrderChange"
+        @start="handleDragStart"
+      >
+        <template #item="{ element: attraction }">
+          <div
+            :class="[
+              'transition-transform duration-150 ease-in-out',
+              planStore.isModifying ? 'cursor-move hover:bg-white/10' : 'cursor-default',
+            ]"
+          >
+            <AttractionItem
+              :key="`${props.date}-${attraction.routeId}`"
+              :order="attraction.order"
+              :name="attraction.name"
+              :visitTime="attraction.visitTime"
+              :address="attraction.address"
+              :memo="attraction.memo ?? ''"
+              :data-id="attraction.routeId"
+              @delete="handleDeleteAttraction(attraction.routeId)"
+            />
+          </div>
+        </template>
+      </draggable>
+
       <button
-        class="mt-2 flex items-center justify-center gap-2 rounded-lg border-2 border-dashed border-white/20 py-2 text-sm text-white transition-colors hover:cursor-pointer hover:border-purple-400/50 hover:bg-white/10"
+        v-if="isAttractionSearchPage"
+        class="mt-4 flex w-full items-center justify-center gap-2 rounded-lg border-2 border-dashed border-white/20 py-2 text-sm text-white transition-colors hover:cursor-pointer hover:border-purple-400/50 hover:bg-white/10"
         @click.stop="handleAddAttraction"
       >
         <Plus class="h-4 w-4 text-white" />
@@ -31,11 +57,15 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue';
+import { ref, watch, computed } from 'vue';
+import { useRoute } from 'vue-router';
 import { Calendar, Plus } from 'lucide-vue-next';
 import { Card, CardHeader, CardContent } from '@/components/ui/card';
 import AttractionItem from '@/components/common/AttractionItem/AttractionItem.vue';
 import type { RouteAttraction } from '@/services/api/domains/plan';
+import { usePlanStore } from '@/stores/plan';
+import { ROUTES } from '@/router/routes';
+import draggable from 'vuedraggable';
 
 const props = defineProps<{
   date: string;
@@ -45,18 +75,113 @@ const props = defineProps<{
 const emit = defineEmits<{
   (e: 'showRoute', date: string, attractions: RouteAttraction[]): void;
   (e: 'addAttraction', date: string): void;
+  (e: 'deleteAttraction', date: string, routeId: number): void;
 }>();
 
-const sortedAttractions = computed(() => {
-  if (!props.attractions || !Array.isArray(props.attractions)) return [];
-  return [...props.attractions].sort((a, b) => a.order - b.order);
+const route = useRoute();
+const planStore = usePlanStore();
+const isDragging = ref(false);
+
+/**
+ * 현재 라우트가 여행지 검색 페이지인지 확인
+ */
+const isAttractionSearchPage = computed(() => {
+  return route.name === ROUTES.PLAN_MODIFY.name;
 });
 
-const showRouteOnMap = () => {
-  emit('showRoute', props.date, props.attractions);
+// 로컬 상태로 관리하는 attractions 배열
+const localAttractions = ref<RouteAttraction[]>([]);
+
+/**
+ * planStore에서 데이터가 변경될 때 로컬 상태 업데이트
+ */
+const updateLocalAttractions = () => {
+  const storeAttractions = planStore.currentPlan?.details?.[props.date];
+  if (storeAttractions && Array.isArray(storeAttractions)) {
+    localAttractions.value = [...storeAttractions].sort((a, b) => a.order - b.order);
+  } else if (props.attractions && Array.isArray(props.attractions)) {
+    localAttractions.value = [...props.attractions].sort((a, b) => a.order - b.order);
+  } else {
+    localAttractions.value = [];
+  }
 };
 
+// 초기 데이터 설정 및 store 변경 감지
+watch(
+  () => [planStore.currentPlan?.details?.[props.date], props.attractions],
+  () => {
+    if (!isDragging.value) {
+      updateLocalAttractions();
+    }
+  },
+  { immediate: true, deep: true }
+);
+
+/**
+ * 지도에서 해당 날짜의 경로를 표시합니다.
+ */
+const showRouteOnMap = () => {
+  const currentAttractions = planStore.currentPlan?.details?.[props.date] || props.attractions;
+  emit('showRoute', props.date, currentAttractions);
+};
+
+/**
+ * 새로운 여행지 추가 이벤트를 emit합니다.
+ */
 const handleAddAttraction = () => {
+  console.log(props.date);
   emit('addAttraction', props.date);
 };
+
+/**
+ * 여행지 삭제 이벤트를 emit합니다.
+ * @param routeId - 삭제할 여행지 ID
+ */
+const handleDeleteAttraction = (routeId: number) => {
+  emit('deleteAttraction', props.date, routeId);
+};
+
+/**
+ * 드래그 시작 시 플래그를 설정합니다.
+ */
+const handleDragStart = () => {
+  isDragging.value = true;
+};
+
+/**
+ * 드래그로 인한 순서 변경을 처리합니다.
+ */
+const handleOrderChange = () => {
+  isDragging.value = false;
+
+  // 현재 localAttractions의 순서를 기반으로 order 재설정
+  const reorderedAttractions = localAttractions.value.map((attraction, index) => ({
+    ...attraction,
+    order: index + 1,
+  }));
+
+  // planStore 업데이트
+  planStore.reorderAttractions(props.date, reorderedAttractions);
+
+  // 변경된 순서로 경로 다시 표시
+  emit('showRoute', props.date, reorderedAttractions);
+};
 </script>
+
+<style scoped>
+.sortable-ghost {
+  opacity: 0.5;
+  background-color: rgba(147, 51, 234, 0.2);
+}
+
+.sortable-chosen {
+  border: 2px solid rgba(147, 51, 234, 0.5);
+  background-color: rgba(147, 51, 234, 0.2);
+}
+
+.sortable-drag {
+  transform: scale(1.05);
+  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.3);
+  background-color: rgba(255, 255, 255, 0.1);
+}
+</style>

--- a/front_end/src/components/card/DailyScheduleCard/DailyScheduleCard.vue
+++ b/front_end/src/components/card/DailyScheduleCard/DailyScheduleCard.vue
@@ -129,7 +129,6 @@ const showRouteOnMap = () => {
  * 새로운 여행지 추가 이벤트를 emit합니다.
  */
 const handleAddAttraction = () => {
-  console.log(props.date);
   emit('addAttraction', props.date);
 };
 

--- a/front_end/src/components/card/DailyScheduleCard/DailyScheduleCard.vue
+++ b/front_end/src/components/card/DailyScheduleCard/DailyScheduleCard.vue
@@ -45,7 +45,7 @@
       </draggable>
 
       <button
-        v-if="isAttractionSearchPage"
+        v-if="isModifyPage"
         class="mt-4 flex w-full items-center justify-center gap-2 rounded-lg border-2 border-dashed border-white/20 py-2 text-sm text-white transition-colors hover:cursor-pointer hover:border-purple-400/50 hover:bg-white/10"
         @click.stop="handleAddAttraction"
       >
@@ -58,14 +58,22 @@
 
 <script setup lang="ts">
 import { ref, watch, computed } from 'vue';
-import { useRoute } from 'vue-router';
 import { Calendar, Plus } from 'lucide-vue-next';
 import { Card, CardHeader, CardContent } from '@/components/ui/card';
 import AttractionItem from '@/components/common/AttractionItem/AttractionItem.vue';
 import type { RouteAttraction } from '@/services/api/domains/plan';
 import { usePlanStore } from '@/stores/plan';
-import { ROUTES } from '@/router/routes';
 import draggable from 'vuedraggable';
+import { ROUTES } from '@/router/routes';
+import { useRoute } from 'vue-router';
+
+const route = useRoute();
+/**
+ * 현재 라우트가 편집 화면인지 확인
+ */
+const isModifyPage = computed(() => {
+  return route.name === ROUTES.PLAN_MODIFY.name;
+});
 
 const props = defineProps<{
   date: string;
@@ -78,16 +86,8 @@ const emit = defineEmits<{
   (e: 'deleteAttraction', date: string, routeId: number): void;
 }>();
 
-const route = useRoute();
 const planStore = usePlanStore();
 const isDragging = ref(false);
-
-/**
- * 현재 라우트가 여행지 검색 페이지인지 확인
- */
-const isAttractionSearchPage = computed(() => {
-  return route.name === ROUTES.PLAN_MODIFY.name;
-});
 
 // 로컬 상태로 관리하는 attractions 배열
 const localAttractions = ref<RouteAttraction[]>([]);

--- a/front_end/src/components/common/AttractionItem/AttractionItem.vue
+++ b/front_end/src/components/common/AttractionItem/AttractionItem.vue
@@ -1,5 +1,20 @@
 <template>
-  <div class="flex gap-3 rounded-lg p-2 transition-colors hover:bg-white/5">
+  <div class="flex gap-3 rounded-lg p-2 transition-all duration-200 hover:bg-white/5">
+    <!-- 드래그 핸들 (수정 모드일 때만 표시) -->
+    <div v-if="planStore.isModifying" class="flex items-center">
+      <div class="drag-handle mr-1 cursor-grab active:cursor-grabbing">
+        <svg
+          class="h-4 w-4 text-gray-500 hover:text-purple-400"
+          fill="currentColor"
+          viewBox="0 0 16 16"
+        >
+          <path
+            d="M7 2a1 1 0 1 1-2 0 1 1 0 0 1 2 0zM7 5a1 1 0 1 1-2 0 1 1 0 0 1 2 0zM7 8a1 1 0 1 1-2 0 1 1 0 0 1 2 0zM7 11a1 1 0 1 1-2 0 1 1 0 0 1 2 0zM11 2a1 1 0 1 1-2 0 1 1 0 0 1 2 0zM11 5a1 1 0 1 1-2 0 1 1 0 0 1 2 0zM11 8a1 1 0 1 1-2 0 1 1 0 0 1 2 0zM11 11a1 1 0 1 1-2 0 1 1 0 0 1 2 0z"
+          />
+        </svg>
+      </div>
+    </div>
+
     <div
       class="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-purple-900/50 text-purple-200"
     >
@@ -9,9 +24,19 @@
     <div class="flex-1">
       <div class="mb-1 flex items-center justify-between">
         <h5 class="font-medium text-white">{{ name }}</h5>
-        <span class="text-sm text-purple-300">
-          {{ formattedTime }}
-        </span>
+        <div class="flex items-center gap-2">
+          <span class="text-sm text-purple-300">
+            {{ formattedTime }}
+          </span>
+          <!-- 삭제 버튼 (수정 모드일 때만 표시) -->
+          <button
+            v-if="planStore.isModifying"
+            class="flex h-6 w-6 items-center justify-center rounded-full bg-red-900/50 text-red-300 transition-colors hover:bg-red-800/70 hover:text-red-200"
+            @click="handleDelete"
+          >
+            <X class="h-3 w-3" />
+          </button>
+        </div>
       </div>
 
       <div class="flex items-start gap-1 text-xs text-gray-400">
@@ -28,7 +53,10 @@
 
 <script setup lang="ts">
 import { computed } from 'vue';
-import { MapPin } from 'lucide-vue-next';
+import { MapPin, X } from 'lucide-vue-next';
+import { usePlanStore } from '@/stores/plan';
+
+const planStore = usePlanStore();
 
 const props = defineProps<{
   order: number;
@@ -36,11 +64,30 @@ const props = defineProps<{
   visitTime?: string;
   address: string;
   memo?: string;
+  isModifying?: boolean;
 }>();
 
+const emit = defineEmits<{
+  delete: [];
+}>();
+
+/**
+ * 시간 문자열을 HH:MM 형식으로 포맷팅합니다.
+ * @returns 포맷된 시간 문자열, visitTime이 없으면 빈 문자열
+ */
 const formattedTime = computed(() => {
   if (!props.visitTime) return '';
   const [hours, minutes] = props.visitTime.split(':');
   return `${hours}:${minutes}`;
 });
+
+const handleDelete = () => {
+  emit('delete');
+};
 </script>
+
+<style scoped>
+.drag-handle:active {
+  @apply cursor-grabbing;
+}
+</style>

--- a/front_end/src/components/common/AttractionItem/AttractionItem.vue
+++ b/front_end/src/components/common/AttractionItem/AttractionItem.vue
@@ -64,7 +64,6 @@ const props = defineProps<{
   visitTime?: string;
   address: string;
   memo?: string;
-  isModifying?: boolean;
 }>();
 
 const emit = defineEmits<{

--- a/front_end/src/components/views/attraction/AttractionDetail/AttractionDetail.vue
+++ b/front_end/src/components/views/attraction/AttractionDetail/AttractionDetail.vue
@@ -162,7 +162,17 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue';
-import { Heart, Star, MapPin, User, PenLine, MessageSquare, ThumbsUp, X } from 'lucide-vue-next';
+import {
+  Heart,
+  Star,
+  MapPin,
+  User,
+  PenLine,
+  MessageSquare,
+  ThumbsUp,
+  X,
+  Plus,
+} from 'lucide-vue-next';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import ImageWithFallback from '@/components/common/ImageWithFallback/ImageWithFallback.vue';

--- a/front_end/src/components/views/attraction/FilteredAttractions/FilteredAttractions.vue
+++ b/front_end/src/components/views/attraction/FilteredAttractions/FilteredAttractions.vue
@@ -24,9 +24,6 @@ const emit = defineEmits<{
 }>();
 
 const handleCardClick = (attraction: Attraction) => {
-  if (props.showAddButton) {
-    return;
-  }
   emit('cardClick', attraction);
 };
 

--- a/front_end/src/components/views/myPlan/myPlans/myPlans.vue
+++ b/front_end/src/components/views/myPlan/myPlans/myPlans.vue
@@ -3,7 +3,7 @@ import { ref, watch } from 'vue';
 import PlanCard from '@/components/card/PlanCard/PlanCard.vue';
 import GridCardListContainer from '@/components/common/GridCardListContainer/GridCardListContainer.vue';
 import AddPlanCard from '@/components/card/AddPlanCard/AddPlanCard.vue';
-import { getPlans, type PlansParams, type Plan, type Tag } from '@/services/api/domains/plan';
+import { type PlansParams, type Plan, type Tag, getMyPlans } from '@/services/api/domains/plan';
 
 interface Props {
   apiParams?: PlansParams;
@@ -22,9 +22,8 @@ const emit = defineEmits<{
 
 const plans = ref<Plan[]>([]);
 
-//TODO: 내 여행 계획으로 변경
 const fetchPlans = async () => {
-  const response = await getPlans(props.apiParams);
+  const response = await getMyPlans();
   plans.value = response.content;
 };
 

--- a/front_end/src/components/views/plan/PlanDetail/ConfirmModal.vue
+++ b/front_end/src/components/views/plan/PlanDetail/ConfirmModal.vue
@@ -1,0 +1,180 @@
+<template>
+  <Dialog :open="isOpen" @update:open="$emit('update:open', $event)">
+    <DialogContent class="border-slate-700 bg-slate-800 sm:max-w-md">
+      <DialogHeader>
+        <DialogTitle class="flex items-center gap-2 text-white">
+          <component :is="getIcon()" :class="getIconClass()" class="h-5 w-5" />
+          {{ title }}
+        </DialogTitle>
+        <DialogDescription v-if="description" class="mt-2 text-gray-300">
+          {{ description }}
+        </DialogDescription>
+      </DialogHeader>
+
+      <!-- 추가 내용이 있는 경우 -->
+      <div v-if="$slots.default || details" class="py-4">
+        <slot />
+
+        <!-- 세부 정보 목록 -->
+        <div v-if="details && details.length > 0" class="space-y-2">
+          <div
+            v-for="(detail, index) in details"
+            :key="index"
+            class="flex items-center justify-between rounded-md bg-slate-700/50 px-3 py-2 text-sm"
+          >
+            <span class="text-gray-300">{{ detail.label }}</span>
+            <span class="font-medium text-white">{{ detail.value }}</span>
+          </div>
+        </div>
+      </div>
+
+      <DialogFooter class="flex gap-2">
+        <Button
+          variant="outline"
+          @click="handleCancel"
+          class="border-slate-600 text-gray-300 hover:bg-slate-700"
+          :disabled="isLoading"
+        >
+          {{ cancelText }}
+        </Button>
+        <Button
+          :variant="variant"
+          @click="handleConfirm"
+          :class="getConfirmButtonClass()"
+          :disabled="isLoading"
+        >
+          <LoaderCircle v-if="isLoading" class="mr-2 h-4 w-4 animate-spin" />
+          <component v-else-if="getConfirmIcon()" :is="getConfirmIcon()" class="mr-2 h-4 w-4" />
+          {{ confirmText }}
+        </Button>
+      </DialogFooter>
+    </DialogContent>
+  </Dialog>
+</template>
+
+<script setup lang="ts">
+import {
+  AlertTriangle,
+  Trash2,
+  LogOut,
+  CheckCircle,
+  Info,
+  LoaderCircle,
+  Save,
+} from 'lucide-vue-next';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+
+// 세부 정보 타입
+interface ConfirmDetail {
+  label: string;
+  value: string;
+}
+
+const props = withDefaults(
+  defineProps<{
+    isOpen: boolean;
+    title: string;
+    description?: string;
+    confirmText?: string;
+    cancelText?: string;
+    variant?: 'default' | 'destructive' | 'secondary' | 'ghost' | 'link' | 'outline';
+    type?: 'warning' | 'danger' | 'info' | 'success' | 'delete' | 'leave';
+    details?: ConfirmDetail[];
+    isLoading?: boolean;
+  }>(),
+  {
+    confirmText: '확인',
+    cancelText: '취소',
+    variant: 'default',
+    type: 'warning',
+    isLoading: false,
+  }
+);
+
+const emit = defineEmits<{
+  'update:open': [value: boolean];
+  'confirm': [];
+  'cancel': [];
+}>();
+
+// 타입에 따른 아이콘 선택
+const getIcon = () => {
+  switch (props.type) {
+    case 'danger':
+    case 'delete':
+      return Trash2;
+    case 'leave':
+      return LogOut;
+    case 'success':
+      return CheckCircle;
+    case 'info':
+      return Info;
+    case 'warning':
+    default:
+      return AlertTriangle;
+  }
+};
+
+// 타입에 따른 아이콘 색상 클래스
+const getIconClass = () => {
+  switch (props.type) {
+    case 'danger':
+    case 'delete':
+    case 'leave':
+      return 'text-red-400';
+    case 'success':
+      return 'text-green-400';
+    case 'info':
+      return 'text-blue-400';
+    case 'warning':
+    default:
+      return 'text-yellow-400';
+  }
+};
+
+// 확인 버튼 아이콘
+const getConfirmIcon = () => {
+  switch (props.type) {
+    case 'delete':
+      return Trash2;
+    case 'leave':
+      return LogOut;
+    case 'success':
+      return Save;
+    default:
+      return null;
+  }
+};
+
+// 확인 버튼 클래스
+const getConfirmButtonClass = () => {
+  const baseClass = 'font-medium';
+
+  switch (props.variant) {
+    case 'destructive':
+      return `${baseClass} bg-red-600 hover:bg-red-700 text-white`;
+    case 'secondary':
+      return `${baseClass} bg-slate-600 hover:bg-slate-700 text-white`;
+    default:
+      return `${baseClass} bg-blue-600 hover:bg-blue-700 text-white`;
+  }
+};
+
+// 이벤트 핸들러
+const handleConfirm = () => {
+  emit('confirm');
+};
+
+const handleCancel = () => {
+  emit('cancel');
+  emit('update:open', false);
+};
+</script>

--- a/front_end/src/components/views/plan/PlanDetail/InviteModal.vue
+++ b/front_end/src/components/views/plan/PlanDetail/InviteModal.vue
@@ -1,0 +1,240 @@
+<template>
+  <Dialog :open="isOpen" @update:open="handleOpenModal">
+    <DialogContent class="border-slate-700 bg-slate-800 sm:max-w-md">
+      <DialogHeader>
+        <DialogTitle class="flex items-center gap-2 text-white">
+          <UserPlus class="h-5 w-5 text-blue-400" />
+          {{ planTitle }} 여행에 초대하기
+        </DialogTitle>
+        <DialogDescription class="text-gray-300">
+          이메일 주소를 입력하여 다른 사용자를 이 여행에 초대하세요.
+        </DialogDescription>
+      </DialogHeader>
+
+      <div class="space-y-4 py-4">
+        <!-- 이메일 입력 -->
+        <div class="space-y-2">
+          <label class="text-sm font-medium text-gray-300">이메일 주소</label>
+          <Input
+            v-model="inviteEmail"
+            placeholder="example@email.com"
+            type="email"
+            class="border-slate-600 bg-slate-700 text-white placeholder:text-gray-400 focus:border-blue-500"
+            :disabled="isLoading"
+            @keyup.enter="sendInvite"
+          />
+        </div>
+
+        <!-- 메시지 입력 (선택사항) -->
+        <div class="space-y-2">
+          <label class="text-sm font-medium text-gray-300">초대 메시지 (선택사항)</label>
+          <Textarea
+            v-model="inviteMessage"
+            placeholder="함께 여행하실래요? 🌟"
+            class="resize-none border-slate-600 bg-slate-700 text-white placeholder:text-gray-400 focus:border-blue-500"
+            rows="3"
+            :disabled="isLoading"
+          />
+        </div>
+
+        <!-- 초대된 사용자 목록 -->
+        <div v-if="invitedUsers.length > 0" class="space-y-2">
+          <label class="text-sm font-medium text-gray-300">이미 초대된 사용자</label>
+          <div class="max-h-24 space-y-1 overflow-y-auto">
+            <div
+              v-for="user in invitedUsers"
+              :key="user.email"
+              class="flex items-center justify-between rounded-md bg-slate-700 px-3 py-2 text-sm"
+            >
+              <span class="text-gray-300">{{ user.email }}</span>
+              <Badge
+                :variant="
+                  user.status === 'pending'
+                    ? 'secondary'
+                    : user.status === 'accepted'
+                      ? 'default'
+                      : 'destructive'
+                "
+                class="text-xs"
+              >
+                {{ getStatusText(user.status) }}
+              </Badge>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <DialogFooter class="flex gap-2">
+        <Button
+          variant="outline"
+          @click="$emit('update:open', false)"
+          class="border-slate-600 text-gray-300 hover:bg-slate-700"
+          :disabled="isLoading"
+        >
+          취소
+        </Button>
+        <Button
+          @click="sendInvite"
+          class="bg-blue-600 text-white hover:bg-blue-700"
+          :disabled="!isValidEmail || isLoading"
+        >
+          <LoaderCircle v-if="isLoading" class="mr-2 h-4 w-4 animate-spin" />
+          <Send v-else class="mr-2 h-4 w-4" />
+          초대 보내기
+        </Button>
+      </DialogFooter>
+    </DialogContent>
+  </Dialog>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch } from 'vue';
+import { toast } from 'vue-sonner';
+import { UserPlus, Send, LoaderCircle } from 'lucide-vue-next';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Badge } from '@/components/ui/badge';
+import { inviteToMyPlan } from '@/services/api/domains/plan'; // 새로운 API 함수 import
+
+// 초대된 사용자 타입
+interface InvitedUser {
+  email: string;
+  status: 'pending' | 'accepted' | 'rejected';
+  invitedAt: string;
+}
+
+const props = defineProps<{
+  isOpen: boolean;
+  planId?: number;
+  planTitle?: string;
+}>();
+
+const emit = defineEmits<{
+  'update:open': [value: boolean];
+}>();
+
+const handleOpenModal = (isOpen: boolean) => {
+  emit('update:open', isOpen);
+};
+
+// 상태 관리
+const inviteEmail = ref('');
+const inviteMessage = ref('');
+const isLoading = ref(false);
+const invitedUsers = ref<InvitedUser[]>([]);
+
+// 이메일 유효성 검사
+const isValidEmail = computed(() => {
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  return emailRegex.test(inviteEmail.value.trim());
+});
+
+// 상태 텍스트 변환
+const getStatusText = (status: string) => {
+  switch (status) {
+    case 'pending':
+      return '대기중';
+    case 'accepted':
+      return '수락됨';
+    case 'rejected':
+      return '거절됨';
+    default:
+      return '알 수 없음';
+  }
+};
+
+// 초대 보내기
+const sendInvite = async () => {
+  if (!isValidEmail.value || !props.planId || isLoading.value) return;
+
+  const email = inviteEmail.value.trim();
+
+  // 이미 초대된 사용자인지 확인
+  if (invitedUsers.value.some(user => user.email === email)) {
+    toast.error('이미 초대된 사용자입니다', {
+      description: '다른 이메일 주소를 입력해주세요.',
+      duration: 3000,
+    });
+    return;
+  }
+
+  try {
+    isLoading.value = true;
+
+    // API 호출 - 초대 보내기 (업데이트된 함수 사용)
+    const result = await inviteToMyPlan(props.planId, email);
+
+    if (result) {
+      // 성공 시 로컬 상태에 추가
+      invitedUsers.value.push({
+        email,
+        status: 'pending',
+        invitedAt: new Date().toISOString(),
+      });
+
+      toast.success('초대를 보냈습니다', {
+        description: `${email}에게 초대 메일이 발송되었습니다.`,
+        duration: 4000,
+      });
+
+      // 입력 필드 초기화
+      inviteEmail.value = '';
+      inviteMessage.value = '';
+    } else {
+      throw new Error('초대 보내기 실패');
+    }
+  } catch (error) {
+    console.error('초대 실패:', error);
+    toast.error('초대 보내기에 실패했습니다', {
+      description: '잠시 후 다시 시도해주세요.',
+      duration: 4000,
+    });
+  } finally {
+    isLoading.value = false;
+  }
+};
+
+// 초대된 사용자 목록 가져오기
+const loadInvitedUsers = async () => {
+  if (!props.planId) return;
+
+  try {
+    // API 호출 - 초대된 사용자 목록 가져오기
+    // const users = await getPlanInvitations(props.planId);
+    // invitedUsers.value = users;
+
+    // 임시 데이터 (실제 API 구현 시 제거)
+    invitedUsers.value = [
+      // {
+      //   email: 'example@test.com',
+      //   status: 'pending',
+      //   invitedAt: new Date().toISOString(),
+      // }
+    ];
+  } catch (error) {
+    console.error('초대 목록 로드 실패:', error);
+  }
+};
+
+// 모달이 열릴 때 초대된 사용자 목록 로드
+watch(
+  () => props.isOpen,
+  isOpen => {
+    if (isOpen) {
+      loadInvitedUsers();
+      // 입력 필드 초기화
+      inviteEmail.value = '';
+      inviteMessage.value = '';
+    }
+  }
+);
+</script>

--- a/front_end/src/components/views/plan/PlanDetail/InviteModal.vue
+++ b/front_end/src/components/views/plan/PlanDetail/InviteModal.vue
@@ -4,10 +4,10 @@
       <DialogHeader>
         <DialogTitle class="flex items-center gap-2 text-white">
           <UserPlus class="h-5 w-5 text-blue-400" />
-          {{ planTitle }} 여행에 초대하기
+          {{ planTitle }} 여행에 사용자 추가
         </DialogTitle>
         <DialogDescription class="text-gray-300">
-          이메일 주소를 입력하여 다른 사용자를 이 여행에 초대하세요.
+          이메일 주소를 입력하여 다른 사용자를 이 여행에 추가하세요.
         </DialogDescription>
       </DialogHeader>
 
@@ -21,46 +21,8 @@
             type="email"
             class="border-slate-600 bg-slate-700 text-white placeholder:text-gray-400 focus:border-blue-500"
             :disabled="isLoading"
-            @keyup.enter="sendInvite"
+            @keyup.enter="addUser"
           />
-        </div>
-
-        <!-- 메시지 입력 (선택사항) -->
-        <div class="space-y-2">
-          <label class="text-sm font-medium text-gray-300">초대 메시지 (선택사항)</label>
-          <Textarea
-            v-model="inviteMessage"
-            placeholder="함께 여행하실래요? 🌟"
-            class="resize-none border-slate-600 bg-slate-700 text-white placeholder:text-gray-400 focus:border-blue-500"
-            rows="3"
-            :disabled="isLoading"
-          />
-        </div>
-
-        <!-- 초대된 사용자 목록 -->
-        <div v-if="invitedUsers.length > 0" class="space-y-2">
-          <label class="text-sm font-medium text-gray-300">이미 초대된 사용자</label>
-          <div class="max-h-24 space-y-1 overflow-y-auto">
-            <div
-              v-for="user in invitedUsers"
-              :key="user.email"
-              class="flex items-center justify-between rounded-md bg-slate-700 px-3 py-2 text-sm"
-            >
-              <span class="text-gray-300">{{ user.email }}</span>
-              <Badge
-                :variant="
-                  user.status === 'pending'
-                    ? 'secondary'
-                    : user.status === 'accepted'
-                      ? 'default'
-                      : 'destructive'
-                "
-                class="text-xs"
-              >
-                {{ getStatusText(user.status) }}
-              </Badge>
-            </div>
-          </div>
         </div>
       </div>
 
@@ -74,13 +36,13 @@
           취소
         </Button>
         <Button
-          @click="sendInvite"
+          @click="addUser"
           class="bg-blue-600 text-white hover:bg-blue-700"
           :disabled="!isValidEmail || isLoading"
         >
           <LoaderCircle v-if="isLoading" class="mr-2 h-4 w-4 animate-spin" />
-          <Send v-else class="mr-2 h-4 w-4" />
-          초대 보내기
+          <UserPlus v-else class="mr-2 h-4 w-4" />
+          사용자 추가
         </Button>
       </DialogFooter>
     </DialogContent>
@@ -90,7 +52,7 @@
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue';
 import { toast } from 'vue-sonner';
-import { UserPlus, Send, LoaderCircle } from 'lucide-vue-next';
+import { UserPlus, LoaderCircle } from 'lucide-vue-next';
 import {
   Dialog,
   DialogContent,
@@ -101,16 +63,7 @@ import {
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { Textarea } from '@/components/ui/textarea';
-import { Badge } from '@/components/ui/badge';
-import { inviteToMyPlan } from '@/services/api/domains/plan'; // 새로운 API 함수 import
-
-// 초대된 사용자 타입
-interface InvitedUser {
-  email: string;
-  status: 'pending' | 'accepted' | 'rejected';
-  invitedAt: string;
-}
+import { inviteToMyPlan } from '@/services/api/domains/plan';
 
 const props = defineProps<{
   isOpen: boolean;
@@ -128,9 +81,7 @@ const handleOpenModal = (isOpen: boolean) => {
 
 // 상태 관리
 const inviteEmail = ref('');
-const inviteMessage = ref('');
 const isLoading = ref(false);
-const invitedUsers = ref<InvitedUser[]>([]);
 
 // 이메일 유효성 검사
 const isValidEmail = computed(() => {
@@ -138,64 +89,31 @@ const isValidEmail = computed(() => {
   return emailRegex.test(inviteEmail.value.trim());
 });
 
-// 상태 텍스트 변환
-const getStatusText = (status: string) => {
-  switch (status) {
-    case 'pending':
-      return '대기중';
-    case 'accepted':
-      return '수락됨';
-    case 'rejected':
-      return '거절됨';
-    default:
-      return '알 수 없음';
-  }
-};
-
-// 초대 보내기
-const sendInvite = async () => {
+// 사용자 추가
+const addUser = async () => {
   if (!isValidEmail.value || !props.planId || isLoading.value) return;
 
   const email = inviteEmail.value.trim();
 
-  // 이미 초대된 사용자인지 확인
-  if (invitedUsers.value.some(user => user.email === email)) {
-    toast.error('이미 초대된 사용자입니다', {
-      description: '다른 이메일 주소를 입력해주세요.',
-      duration: 3000,
-    });
-    return;
-  }
-
   try {
     isLoading.value = true;
 
-    // API 호출 - 초대 보내기 (업데이트된 함수 사용)
     const result = await inviteToMyPlan(props.planId, email);
 
     if (result) {
-      // 성공 시 로컬 상태에 추가
-      invitedUsers.value.push({
-        email,
-        status: 'pending',
-        invitedAt: new Date().toISOString(),
-      });
-
-      toast.success('초대를 보냈습니다', {
-        description: `${email}에게 초대 메일이 발송되었습니다.`,
+      toast.success('사용자가 여행에 추가되었습니다', {
+        description: `${email} 사용자가 추가되었습니다.`,
         duration: 4000,
       });
 
-      // 입력 필드 초기화
+      // 입력 필드 초기화 후 모달 닫기
       inviteEmail.value = '';
-      inviteMessage.value = '';
-    } else {
-      throw new Error('초대 보내기 실패');
+      emit('update:open', false);
     }
   } catch (error) {
-    console.error('초대 실패:', error);
-    toast.error('초대 보내기에 실패했습니다', {
-      description: '잠시 후 다시 시도해주세요.',
+    console.error('사용자 추가 실패:', error);
+    toast.error('사용자 추가에 실패했습니다', {
+      description: '존재하지 않는 사용자이거나 오류가 발생했습니다.',
       duration: 4000,
     });
   } finally {
@@ -203,37 +121,12 @@ const sendInvite = async () => {
   }
 };
 
-// 초대된 사용자 목록 가져오기
-const loadInvitedUsers = async () => {
-  if (!props.planId) return;
-
-  try {
-    // API 호출 - 초대된 사용자 목록 가져오기
-    // const users = await getPlanInvitations(props.planId);
-    // invitedUsers.value = users;
-
-    // 임시 데이터 (실제 API 구현 시 제거)
-    invitedUsers.value = [
-      // {
-      //   email: 'example@test.com',
-      //   status: 'pending',
-      //   invitedAt: new Date().toISOString(),
-      // }
-    ];
-  } catch (error) {
-    console.error('초대 목록 로드 실패:', error);
-  }
-};
-
-// 모달이 열릴 때 초대된 사용자 목록 로드
+// 모달이 열릴 때 입력 필드 초기화
 watch(
   () => props.isOpen,
   isOpen => {
     if (isOpen) {
-      loadInvitedUsers();
-      // 입력 필드 초기화
       inviteEmail.value = '';
-      inviteMessage.value = '';
     }
   }
 );

--- a/front_end/src/components/views/plan/PlanDetail/PlanDetail.vue
+++ b/front_end/src/components/views/plan/PlanDetail/PlanDetail.vue
@@ -64,7 +64,7 @@ const props = defineProps<{
 
 // Emits
 const emit = defineEmits<{
-  (e: 'addAttraction', date: string): void;
+  (e: 'moveToAttractionSearch', date: string): void;
 }>();
 
 const { selectPlanDetail, showRoute, clearPolylines, clearMarkers } = useMapState();
@@ -76,7 +76,7 @@ const selectedDate = ref<string | null>(null);
 
 // 여행지 추가 버튼 클릭 핸들러
 const handleAddAttraction = (date: string) => {
-  emit('addAttraction', date);
+  emit('moveToAttractionSearch', date);
 };
 
 // 좋아요 토글

--- a/front_end/src/components/views/plan/PlanDetail/PlanDetail.vue
+++ b/front_end/src/components/views/plan/PlanDetail/PlanDetail.vue
@@ -10,18 +10,31 @@
     <div class="flex-1 bg-slate-900/20 p-3">
       <div class="mb-3 flex items-center justify-between">
         <h3 class="p-2 text-lg font-semibold text-purple-200">일정</h3>
-        <div v-if="selectedDate" class="flex items-center">
-          <Badge variant="outline" class="border-purple-400/30 bg-purple-900/30 text-purple-200">
-            {{ selectedDate }} 경로 표시 중
-          </Badge>
+        <div class="flex items-center gap-2">
+          <!-- 일정 편집 버튼 -->
           <Button
-            variant="ghost"
+            variant="outline"
             size="sm"
-            class="ml-2 text-purple-200 hover:bg-purple-900/30"
-            @click="resetRoute"
+            class="border-blue-500/50 bg-blue-900/30 text-blue-300 hover:bg-blue-800/50 hover:text-blue-200"
+            @click="handleToggleScheduleEdit"
           >
-            <X class="h-4 w-4" />
+            {{ planStore.isModifying ? '편집 완료' : '일정 편집' }}
           </Button>
+
+          <!-- 경로 표시 중 배지 -->
+          <div v-if="selectedDate" class="flex items-center">
+            <Badge variant="outline" class="border-purple-400/30 bg-purple-900/30 text-purple-200">
+              {{ selectedDate }} 경로 표시 중
+            </Badge>
+            <Button
+              variant="ghost"
+              size="sm"
+              class="ml-2 text-purple-200 hover:bg-purple-900/30"
+              @click="resetRoute"
+            >
+              <X class="h-4 w-4" />
+            </Button>
+          </div>
         </div>
       </div>
 
@@ -34,6 +47,7 @@
           :attractions="attractions"
           @showRoute="showRouteOnMap"
           @addAttraction="handleAddAttraction"
+          @deleteAttraction="handleDeleteAttraction"
         />
       </div>
 
@@ -44,7 +58,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onUnmounted, watch } from 'vue';
+import { ref, computed, onMounted, onUnmounted, watch } from 'vue';
 import { X } from 'lucide-vue-next';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -54,7 +68,6 @@ import DailySchedule from '@/components/card/DailyScheduleCard/DailyScheduleCard
 import EmptySchedule from './EmptySchedule.vue';
 import { getPlanDetail, type PlanDetail, type RouteAttraction } from '@/services/api/domains/plan';
 import { useMapState } from '@/composables/useMapState';
-import { fillPlanDetails } from '@/utils/planUtils';
 import { usePlanStore } from '@/stores/plan';
 import type { MarkerInfo } from '@/types/kakao';
 
@@ -65,22 +78,57 @@ const props = defineProps<{
 // Emits
 const emit = defineEmits<{
   (e: 'moveToAttractionSearch', date: string): void;
+  (e: 'toggleScheduleEdit'): void;
 }>();
 
 const { selectPlanDetail, showRoute, clearPolylines, clearMarkers } = useMapState();
 const planStore = usePlanStore();
 
-// Store에서 현재 플랜 데이터 가져오기
+// Store에서 현재 플랜 데이터 가져오기 (reactive)
 const planDetail = computed(() => planStore.currentPlan);
 const selectedDate = ref<string | null>(null);
 
-// 여행지 추가 버튼 클릭 핸들러
+/**
+ * 여행지 추가 버튼 클릭 핸들러
+ * @param date - 선택된 날짜
+ */
 const handleAddAttraction = (date: string) => {
   emit('moveToAttractionSearch', date);
 };
 
-// 좋아요 토글
-const toggleLike = (planId: number) => {};
+/**
+ * 여행지 삭제 핸들러
+ * @param date - 대상 날짜
+ * @param routeId - 삭제할 여행지 ID
+ */
+const handleDeleteAttraction = (date: string, routeId: number) => {
+  planStore.removeAttractionFromDate(date, routeId);
+
+  // 현재 선택된 날짜의 경로가 표시 중이라면 업데이트
+  if (selectedDate.value === date && planDetail.value?.details?.[date]) {
+    const updatedAttractions = planDetail.value.details[date];
+    if (updatedAttractions.length > 0) {
+      showRouteOnMap(date, updatedAttractions);
+    } else {
+      resetRoute();
+    }
+  }
+};
+
+/**
+ * 일정 편집 모드 토글
+ */
+const handleToggleScheduleEdit = () => {
+  emit('toggleScheduleEdit');
+};
+
+/**
+ * 좋아요 토글
+ * @param planId - 플랜 ID
+ */
+const toggleLike = (planId: number) => {
+  // TODO: 좋아요 기능 구현
+};
 
 // 배경 별 생성
 const backgroundStars = Array.from({ length: 30 }, () => ({
@@ -91,7 +139,12 @@ const backgroundStars = Array.from({ length: 30 }, () => ({
   duration: Math.random() * 2 + 2,
 }));
 
-// RouteAttraction을 MarkerInfo로 변환
+/**
+ * RouteAttraction을 MarkerInfo로 변환
+ * @param attractions - 여행지 배열
+ * @param date - 날짜
+ * @returns MarkerInfo 배열
+ */
 const convertToMarkerInfos = (attractions: RouteAttraction[], date: string): MarkerInfo[] => {
   return attractions
     .map(attr => ({
@@ -104,7 +157,11 @@ const convertToMarkerInfos = (attractions: RouteAttraction[], date: string): Mar
     .filter(info => !isNaN(info.lat) && !isNaN(info.lng));
 };
 
-// 일별 경로 지도에 표시
+/**
+ * 일별 경로를 지도에 표시
+ * @param date - 선택된 날짜
+ * @param attractions - 해당 날짜의 여행지 배열
+ */
 const showRouteOnMap = (date: string, attractions: RouteAttraction[]) => {
   selectedDate.value = date;
 
@@ -127,7 +184,9 @@ const showRouteOnMap = (date: string, attractions: RouteAttraction[]) => {
   }
 };
 
-// 경로 초기화
+/**
+ * 경로 표시 초기화
+ */
 const resetRoute = () => {
   selectedDate.value = null;
 
@@ -138,34 +197,55 @@ const resetRoute = () => {
   }
 };
 
-// 비동기 초기화 데이터 로드
+/**
+ * 플랜 데이터 초기화
+ */
 const initializeData = async () => {
+  // API에서 플랜 데이터 가져오기
   const data = await getPlanDetail(props.planId);
 
-  // 모든 날짜에 대해 details 채우기
-  const filledData = data ? fillPlanDetails(data) : null;
-  planStore.setPlanDetail(filledData);
+  planStore.setPlanDetail(data);
 
-  if (filledData) {
-    selectPlanDetail(filledData);
+  // 지도에 표시
+  if (data) {
+    selectPlanDetail(data);
   }
-
-  return filledData;
 };
+
+// planDetail의 변경사항을 지도에 반영 (순서 변경 시 자동 업데이트)
+watch(
+  () => planDetail.value,
+  newPlan => {
+    if (newPlan && selectedDate.value && newPlan.details?.[selectedDate.value]) {
+      // 현재 선택된 날짜의 경로가 있다면 지도 업데이트
+      const attractions = newPlan.details[selectedDate.value];
+      showRouteOnMap(selectedDate.value, attractions);
+    } else if (newPlan) {
+      // 전체 플랜 표시
+      selectPlanDetail(newPlan as PlanDetail);
+    }
+  },
+  { deep: true }
+);
+
+// planId 변경 감지
+watch(
+  () => props.planId,
+  async (newId, oldId) => {
+    if (newId !== oldId) {
+      selectedDate.value = null; // 선택된 날짜 초기화
+      await initializeData();
+    }
+  }
+);
+
+// 컴포넌트 마운트 시 초기 데이터 로드
+onMounted(async () => {
+  await initializeData();
+});
 
 onUnmounted(() => {
   clearPolylines();
   clearMarkers();
 });
-
-await initializeData();
-
-watch(
-  () => props.planId,
-  async (newId, oldId) => {
-    if (newId !== oldId) {
-      await initializeData();
-    }
-  }
-);
 </script>

--- a/front_end/src/components/views/plan/PlanDetail/PlanDetail.vue
+++ b/front_end/src/components/views/plan/PlanDetail/PlanDetail.vue
@@ -317,11 +317,11 @@ const saveChangesAndReleaseLock = async () => {
 
       let description = '';
       if (deletedCount > 0 && modifiedCount > 0) {
-        description = `${modifiedCount}개 경로 수정, ${deletedCount}개 경로 삭제`;
+        description = `경로 수정, 삭제`;
       } else if (deletedCount > 0) {
         description = `${deletedCount}개 경로가 삭제되었습니다`;
       } else {
-        description = `${modifiedCount}개 경로가 수정되었습니다`;
+        description = `경로가 수정되었습니다`;
       }
 
       toast.success('변경사항이 저장되었습니다', {

--- a/front_end/src/components/views/plan/PlanDetail/PlanInfo.vue
+++ b/front_end/src/components/views/plan/PlanDetail/PlanInfo.vue
@@ -2,7 +2,7 @@
   <Card class="border-0 bg-slate-900/30 shadow-none">
     <CardContent class="space-y-3 p-3">
       <div class="flex items-center justify-between">
-        <div class="flex flex-wrap gap-2">
+        <div class="flex flex-wrap items-center gap-2">
           <Tag
             v-for="tag in plan?.tags"
             :key="tag.tagId"
@@ -10,6 +10,7 @@
             class="rounded-md border-purple-400/50 bg-purple-900/20 text-purple-200"
           />
         </div>
+
         <Button
           variant="ghost"
           size="sm"
@@ -39,10 +40,20 @@
           <span
             v-for="writer in plan?.planWriters"
             :key="writer.userId"
-            class="inline-block rounded-full bg-purple-900/30 px-2 py-0.5"
+            class="flex items-center justify-center rounded-full bg-purple-900/30 px-2 py-0.5"
           >
             {{ writer.name }}
           </span>
+          <!-- 초대하기 버튼 -->
+          <Button
+            variant="ghost"
+            size="sm"
+            class="flex items-center gap-1.5 rounded-full border border-blue-500/30 px-3 py-1 text-blue-300 hover:bg-blue-900/30"
+            @click="handleInvite"
+          >
+            <UserPlus class="h-3 w-3" />
+            <span class="text-xs font-medium">초대하기</span>
+          </Button>
         </div>
       </div>
     </CardContent>
@@ -50,7 +61,7 @@
 </template>
 
 <script setup lang="ts">
-import { Heart, Calendar, Users } from 'lucide-vue-next';
+import { Heart, Calendar, Users, UserPlus } from 'lucide-vue-next';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import Tag from '@/components/common/Tag/Tag.vue';
@@ -62,6 +73,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   toggleLike: [planId: number];
+  invite: [planId: number];
 }>();
 
 // 날짜 범위 표시 형식
@@ -80,6 +92,12 @@ const formatDateRange = (startDate?: string, endDate?: string) => {
 const handleClick = () => {
   if (props.plan?.planId) {
     emit('toggleLike', props.plan.planId);
+  }
+};
+
+const handleInvite = () => {
+  if (props.plan?.planId) {
+    emit('invite', props.plan.planId);
   }
 };
 </script>

--- a/front_end/src/components/views/plan/PlanFormModal.vue
+++ b/front_end/src/components/views/plan/PlanFormModal.vue
@@ -1,0 +1,338 @@
+<template>
+  <Dialog :open="isOpen" @update:open="$emit('update:open', $event)">
+    <DialogContent class="w-full max-w-lg border-0 bg-transparent p-0 shadow-none">
+      <div
+        class="relative overflow-hidden rounded-2xl border border-white/20 bg-white/10 backdrop-blur-md"
+      >
+        <!-- 그라데이션 오버레이 -->
+        <div
+          class="absolute inset-0 bg-gradient-to-br from-slate-900/80 via-purple-950/80 to-indigo-950/80"
+        />
+
+        <!-- 콘텐츠 -->
+        <div class="relative p-6">
+          <DialogHeader class="mb-6">
+            <DialogTitle class="text-2xl font-bold text-white">
+              {{ isEditMode ? '✏️ 여행 계획 수정' : '✨ 새로운 여행 계획' }}
+            </DialogTitle>
+          </DialogHeader>
+
+          <Form class="space-y-6" @submit="onSubmit">
+            <!-- 제목 입력 -->
+            <FormField v-slot="{ componentField }" name="title">
+              <FormItem>
+                <FormLabel class="text-sm font-medium text-purple-200">제목</FormLabel>
+                <FormControl>
+                  <Input
+                    v-bind="componentField"
+                    v-model="form.title"
+                    placeholder="어떤 여행을 계획하고 계신가요?"
+                    required
+                    class="border-white/20 bg-white/10 text-white backdrop-blur-sm transition-all duration-200 focus:border-purple-400/50 focus:bg-white/15 focus:ring-purple-400/30 [&::placeholder]:text-gray-400"
+                  />
+                </FormControl>
+                <FormMessage class="text-red-300" />
+              </FormItem>
+            </FormField>
+
+            <!-- 설명 입력 -->
+            <FormField v-slot="{ componentField }" name="description">
+              <FormItem>
+                <FormLabel class="text-sm font-medium text-purple-200">설명</FormLabel>
+                <FormControl>
+                  <Textarea
+                    v-bind="componentField"
+                    v-model="form.description"
+                    placeholder="여행에 대한 간단한 설명을 적어주세요"
+                    required
+                    rows="3"
+                    class="resize-none border-white/20 bg-white/10 text-white backdrop-blur-sm transition-all duration-200 focus:border-purple-400/50 focus:bg-white/15 focus:ring-purple-400/30 [&::placeholder]:text-gray-400"
+                  />
+                </FormControl>
+                <FormMessage class="text-red-300" />
+              </FormItem>
+            </FormField>
+
+            <!-- 태그 입력 -->
+            <FormField v-slot="{ componentField }" name="tags">
+              <FormItem>
+                <FormLabel class="text-sm font-medium text-purple-200">태그</FormLabel>
+                <FormControl>
+                  <Input
+                    v-bind="componentField"
+                    v-model="tagInput"
+                    placeholder="태그를 쉼표로 구분해서 입력해주세요 (예: 힐링, 자연, 맛집)"
+                    class="border-white/20 bg-white/10 text-white backdrop-blur-sm transition-all duration-200 focus:border-purple-400/50 focus:bg-white/15 focus:ring-purple-400/30 [&::placeholder]:text-gray-400"
+                  />
+                </FormControl>
+                <FormDescription class="text-xs text-purple-200/70">
+                  쉼표로 구분하여 여러 태그를 입력할 수 있습니다
+                </FormDescription>
+                <FormMessage class="text-red-300" />
+              </FormItem>
+            </FormField>
+
+            <!-- 날짜 범위 선택 -->
+            <FormField name="dateRange">
+              <FormItem class="flex flex-col">
+                <FormLabel class="text-sm font-medium text-purple-200">여행 기간</FormLabel>
+                <Popover>
+                  <PopoverTrigger asChild>
+                    <FormControl>
+                      <Button
+                        variant="outline"
+                        :class="[
+                          'w-full justify-start border-white/20 bg-white/10 text-left font-normal text-white backdrop-blur-sm transition-all duration-200 hover:border-purple-400/50 hover:bg-white/15 focus:border-purple-400/50 focus:ring-purple-400/30',
+                          (!form.startDate || !form.endDate) && 'text-gray-400',
+                        ]"
+                      >
+                        <CalendarIcon class="mr-2 h-4 w-4 text-purple-400" />
+                        <span v-if="form.startDate && form.endDate">
+                          {{ formatDateValue(dateRange.start) }} ~
+                          {{ formatDateValue(dateRange.end) }}
+                        </span>
+                        <span v-else-if="form.startDate">
+                          {{ formatDateValue(dateRange.start) }} ~ 종료일 선택
+                        </span>
+                        <span v-else>여행 날짜를 선택해주세요</span>
+                      </Button>
+                    </FormControl>
+                  </PopoverTrigger>
+                  <PopoverContent class="w-auto border-white/20 bg-white/10 p-0 backdrop-blur-md">
+                    <RangeCalendar
+                      v-model="dateRange"
+                      class="rounded-md border-0 bg-transparent text-white [&_[role=gridcell]]:text-white [&_[role=gridcell]:hover]:bg-white/20 [&_[role=gridcell][data-range-middle]]:bg-purple-300/50 [&_[role=gridcell][data-selected]]:bg-purple-500 [&_[role=gridcell][data-selected]]:text-white [&_button]:text-white [&_button:hover]:bg-white/20"
+                      :numberOfMonths="2"
+                      @update:modelValue="handleDateRangeChange"
+                    />
+                  </PopoverContent>
+                </Popover>
+                <FormDescription class="text-xs text-purple-200/70">
+                  시작일과 종료일을 선택해주세요
+                </FormDescription>
+                <FormMessage class="text-red-300" />
+              </FormItem>
+            </FormField>
+
+            <!-- 공개 설정 -->
+            <FormField name="isPublic">
+              <FormItem class="flex flex-row items-start space-y-0 space-x-3">
+                <FormControl>
+                  <Checkbox
+                    :checked="form.isPublic"
+                    class="border-white/20 bg-white/10 text-purple-400 focus:ring-purple-400/30 data-[state=checked]:border-purple-500 data-[state=checked]:bg-purple-500"
+                    @update:checked="form.isPublic = $event"
+                  />
+                </FormControl>
+                <div class="space-y-1 leading-none">
+                  <FormLabel class="cursor-pointer text-sm font-medium text-purple-200">
+                    다른 사람들과 공유하기
+                  </FormLabel>
+                  <FormDescription class="text-xs text-purple-200/70">
+                    공개로 설정하면 다른 사용자들도 회원님의 여행 계획을 볼 수 있습니다
+                  </FormDescription>
+                </div>
+              </FormItem>
+            </FormField>
+
+            <!-- 버튼들 -->
+            <div class="flex justify-end gap-3 pt-4">
+              <Button
+                type="button"
+                variant="ghost"
+                class="border border-white/20 bg-white/10 text-white backdrop-blur-sm hover:border-white/30 hover:bg-white/20 focus:ring-white/30"
+                @click="$emit('update:open', false)"
+              >
+                취소
+              </Button>
+              <Button
+                type="submit"
+                :disabled="isSubmitting"
+                class="bg-gradient-to-r from-purple-500 to-indigo-500 font-medium text-white shadow-lg shadow-purple-500/25 hover:from-purple-600 hover:to-indigo-600 focus:ring-purple-400/50 disabled:opacity-50"
+              >
+                <LoaderCircle v-if="isSubmitting" class="mr-2 h-4 w-4 animate-spin" />
+                <span v-if="isSubmitting">{{ isEditMode ? '수정 중...' : '추가 중...' }}</span>
+                <span v-else>{{ isEditMode ? '✏️ 계획 수정' : '✨ 계획 추가' }}</span>
+              </Button>
+            </div>
+          </Form>
+        </div>
+      </div>
+    </DialogContent>
+  </Dialog>
+</template>
+
+<script setup lang="ts">
+import { ref, watch, type Ref } from 'vue';
+import { CalendarIcon, LoaderCircle } from 'lucide-vue-next';
+import { type DateValue, getLocalTimeZone, today, parseDate } from '@internationalized/date';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Checkbox } from '@/components/ui/checkbox';
+import { RangeCalendar } from '@/components/ui/range-calendar';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import type { DateRange } from 'reka-ui';
+import type { PlanDetail, CreatePlanRequest } from '@/services/api/domains/plan';
+
+const props = defineProps<{
+  isOpen: boolean;
+  isEditMode?: boolean;
+  initialData?: PlanDetail | null;
+  isSubmitting?: boolean;
+}>();
+
+const emit = defineEmits<{
+  'update:open': [value: boolean];
+  'submit': [data: CreatePlanRequest];
+}>();
+
+const start = today(getLocalTimeZone());
+const end = start.add({ days: 7 });
+
+/**
+ * 날짜 값을 "월 일" 형식으로 포맷팅합니다.
+ * @param dateValue - 포맷팅할 날짜 값
+ * @returns 포맷된 날짜 문자열
+ */
+const formatDateValue = (dateValue: DateValue | undefined) => {
+  if (!dateValue) return '';
+  return `${dateValue.month}월 ${dateValue.day}일`;
+};
+
+/**
+ * DateValue를 YYYY-MM-DD 문자열로 변환합니다.
+ * @param dateValue - 변환할 날짜 값
+ * @returns 날짜 문자열
+ */
+const dateValueToString = (dateValue: DateValue | undefined): string => {
+  if (!dateValue) return '';
+  return `${dateValue.year}-${String(dateValue.month).padStart(2, '0')}-${String(dateValue.day).padStart(2, '0')}`;
+};
+
+/**
+ * YYYY-MM-DD 문자열을 DateValue로 변환합니다.
+ * @param dateString - 변환할 날짜 문자열
+ * @returns DateValue 또는 undefined
+ */
+const stringToDateValue = (dateString: string): DateValue | undefined => {
+  if (!dateString) return undefined;
+  try {
+    return parseDate(dateString);
+  } catch {
+    return undefined;
+  }
+};
+
+const dateRange = ref({
+  start,
+  end,
+}) as Ref<DateRange>;
+
+const form = ref<CreatePlanRequest>({
+  title: '',
+  description: '',
+  tags: [],
+  isPublic: true,
+  startDate: '',
+  endDate: '',
+});
+
+const tagInput = ref('');
+
+/**
+ * 날짜 범위 변경 핸들러
+ * @param range - 선택된 날짜 범위
+ */
+const handleDateRangeChange = (range: {
+  start: DateValue | undefined;
+  end: DateValue | undefined;
+}) => {
+  dateRange.value = range;
+  form.value.startDate = dateValueToString(range.start);
+  form.value.endDate = dateValueToString(range.end);
+};
+
+/**
+ * 폼 초기화
+ */
+const resetForm = () => {
+  form.value = {
+    title: '',
+    description: '',
+    tags: [],
+    isPublic: true,
+    startDate: '',
+    endDate: '',
+  };
+  tagInput.value = '';
+  dateRange.value = { start, end };
+};
+
+/**
+ * 초기 데이터로 폼 설정
+ * @param data - 초기 데이터
+ */
+const setFormData = (data: PlanDetail) => {
+  form.value = {
+    title: data.title || '',
+    description: data.description || '',
+    tags: data.tags?.map(tag => tag.name) || [],
+    isPublic: data.isPublic ?? true,
+    startDate: data.startDate || '',
+    endDate: data.endDate || '',
+  };
+
+  tagInput.value = form.value.tags.join(', ');
+
+  const startDateValue = stringToDateValue(data.startDate);
+  const endDateValue = stringToDateValue(data.endDate);
+
+  dateRange.value = {
+    start: startDateValue || start,
+    end: endDateValue || end,
+  };
+};
+
+/**
+ * 폼 제출 핸들러
+ */
+const onSubmit = async () => {
+  const tags = tagInput.value
+    .split(',')
+    .map(t => t.trim())
+    .filter(t => t.length > 0);
+
+  const formData: CreatePlanRequest = {
+    ...form.value,
+    tags,
+  };
+
+  emit('submit', formData);
+};
+
+// props 변경 감지하여 폼 초기화/설정
+watch(
+  () => [props.isOpen, props.initialData],
+  ([isOpen, initialData]) => {
+    if (isOpen) {
+      if (props.isEditMode && initialData) {
+        setFormData(initialData as PlanDetail);
+      } else {
+        resetForm();
+      }
+    }
+  },
+  { immediate: true }
+);
+</script>

--- a/front_end/src/services/api/domains/plan/index.ts
+++ b/front_end/src/services/api/domains/plan/index.ts
@@ -1,14 +1,16 @@
 import { PLAN } from '../../endpoint';
 import api from '../../api';
-import type { ApiResponse, PagenationResponse } from '../../types';
+import type { ApiResponse, PagenationResponse, PagenationParams } from '../../types';
 import type {
   Plan,
   PlansParams,
   Tag,
   PlanDetail,
   CreatePlanRequest,
-  CreatedPlanResponse,
   PlanAttractionRequest,
+  UpdatePlanInfoRequest,
+  UpdatePlanScheduleRequest,
+  LockResponse,
 } from './types';
 
 /**
@@ -49,17 +51,76 @@ export const getPlanDetail = async (planId: number): Promise<PlanDetail> => {
  * @param data 여행 계획 데이터
  * @returns 생성된 여행 계획 정보
  */
-export const createPlan = async (data: CreatePlanRequest): Promise<CreatedPlanResponse> => {
-  const response = await api.post<ApiResponse<CreatedPlanResponse>>(PLAN.PLANS, data);
+export const createPlan = async (data: CreatePlanRequest): Promise<PlanDetail> => {
+  const response = await api.post<ApiResponse<PlanDetail>>(PLAN.PLANS, data);
 
   return response.data.body;
 };
 
+/**
+ * 여행 계획 수정 (락 확인 필요 X)
+ * @param data 여행 계획 데이터
+ * @returns 변경된 여행 계획 정보
+ */
+export const updatePlanInfo = async (
+  planId: number,
+  data: UpdatePlanInfoRequest
+): Promise<PlanDetail> => {
+  const response = await api.put<ApiResponse<PlanDetail>>(PLAN.DETAIL(planId), data);
+
+  return response.data.body;
+};
+
+/**
+ * 여행 계획 일정 수정 (락 확인 필요)
+ * @param data 여행 계획 일정 데이터
+ * @returns 변경된 여행 계획 정보
+ */
+export const updatePlanSchedule = async (
+  planId: number,
+  data: UpdatePlanScheduleRequest
+): Promise<PlanDetail> => {
+  const response = await api.put<ApiResponse<PlanDetail>>(PLAN.SCHEDULE(planId), data);
+
+  return response.data.body;
+};
+
+/**
+ * 락 확인
+ * @param planId planId
+ * @returns LockResponse
+ */
+export const checkLock = async (planId: number): Promise<LockResponse> => {
+  const response = await api.get<ApiResponse<LockResponse>>(PLAN.LOCK(planId));
+
+  return response.data.body;
+};
+
+/**
+ * 여행 계획의 특정 일자에 여행지 추가
+ * @param planId planId
+ * @param data 특정 일자 index (1부터 시작)
+ * @returns 업데이트된 여행 계획
+ */
 export const addAttractionToDate = async (
   planId: number,
   data: PlanAttractionRequest
 ): Promise<PlanDetail> => {
   const response = await api.post<ApiResponse<PlanDetail>>(PLAN.ADD_ATTRACTIONS(planId), data);
+
+  return response.data.body;
+};
+
+// --- 사용자 여행 계획 --- //
+
+/**
+ * query parameter를 바탕으로 여행 계획 리스트 조회
+ * @returns 여행 계획 리스트
+ */
+export const getMyPlans = async (params?: PagenationParams): Promise<PagenationResponse<Plan>> => {
+  const response = await api.get<ApiResponse<PagenationResponse<Plan>>>(PLAN.MY_PLANS, {
+    params,
+  });
 
   return response.data.body;
 };

--- a/front_end/src/services/api/domains/plan/index.ts
+++ b/front_end/src/services/api/domains/plan/index.ts
@@ -3,7 +3,7 @@ import api from '../../api';
 import type {
   ApiResponse,
   PagenationResponse,
-  PagenationParams,
+  PaginationParams,
   CommonSuccessBody,
 } from '../../types';
 import type {
@@ -162,7 +162,7 @@ export const returnLock = async (planId: number): Promise<CommonSuccessBody> => 
  * query parameter를 바탕으로 여행 계획 리스트 조회
  * @returns 여행 계획 리스트
  */
-export const getMyPlans = async (params?: PagenationParams): Promise<PagenationResponse<Plan>> => {
+export const getMyPlans = async (params?: PaginationParams): Promise<PagenationResponse<Plan>> => {
   const response = await api.get<ApiResponse<PagenationResponse<Plan>>>(PLAN.MY_PLANS, {
     params,
   });
@@ -176,8 +176,7 @@ export const getMyPlans = async (params?: PagenationParams): Promise<PagenationR
  * @returns
  */
 export const inviteToMyPlan = async (planId: number, email: string): Promise<boolean> => {
-  const response = await api.post<ApiResponse<boolean>>(PLAN.INVITE(planId), { data: { email } });
-
+  const response = await api.post<ApiResponse<boolean>>(PLAN.INVITE(planId), { email });
   return response.data.body;
 };
 

--- a/front_end/src/services/api/domains/plan/index.ts
+++ b/front_end/src/services/api/domains/plan/index.ts
@@ -1,6 +1,11 @@
 import { PLAN } from '../../endpoint';
 import api from '../../api';
-import type { ApiResponse, PagenationResponse, PagenationParams } from '../../types';
+import type {
+  ApiResponse,
+  PagenationResponse,
+  PagenationParams,
+  CommonSuccessBody,
+} from '../../types';
 import type {
   Plan,
   PlansParams,
@@ -11,6 +16,7 @@ import type {
   UpdatePlanInfoRequest,
   UpdatePlanScheduleRequest,
   LockResponse,
+  UpdateRouteRequest,
 } from './types';
 
 /**
@@ -86,12 +92,16 @@ export const updatePlanSchedule = async (
 };
 
 /**
- * 락 확인
+ * 여행 계획 경로 수정 (락 확인 필요)
  * @param planId planId
- * @returns LockResponse
+ * @param data 경로 데이터
+ * @returns 변경된 여행 계획 정보
  */
-export const checkLock = async (planId: number): Promise<LockResponse> => {
-  const response = await api.get<ApiResponse<LockResponse>>(PLAN.LOCK(planId));
+export const updateRoute = async (
+  planId: number,
+  data: UpdateRouteRequest
+): Promise<PlanDetail> => {
+  const response = await api.patch<ApiResponse<PlanDetail>>(PLAN.ATTRACTIONS(planId), data);
 
   return response.data.body;
 };
@@ -106,7 +116,42 @@ export const addAttractionToDate = async (
   planId: number,
   data: PlanAttractionRequest
 ): Promise<PlanDetail> => {
-  const response = await api.post<ApiResponse<PlanDetail>>(PLAN.ADD_ATTRACTIONS(planId), data);
+  const response = await api.post<ApiResponse<PlanDetail>>(PLAN.ATTRACTIONS(planId), data);
+
+  return response.data.body;
+};
+
+// --- 락 --- //
+
+/**
+ * 락 확인
+ * @param planId planId
+ * @returns LockResponse
+ */
+export const checkLock = async (planId: number): Promise<LockResponse> => {
+  const response = await api.get<ApiResponse<LockResponse>>(PLAN.LOCK_CHECK(planId));
+
+  return response.data.body;
+};
+
+/**
+ * 락 획득
+ * @param planId planId
+ * @returns LockResponse
+ */
+export const getLock = async (planId: number): Promise<CommonSuccessBody> => {
+  const response = await api.post<ApiResponse<CommonSuccessBody>>(PLAN.LOCK(planId));
+
+  return response.data.body;
+};
+
+/**
+ * 락 반환
+ * @param planId planId
+ * @returns LockResponse
+ */
+export const returnLock = async (planId: number): Promise<CommonSuccessBody> => {
+  const response = await api.post<ApiResponse<CommonSuccessBody>>(PLAN.UNLOCK(planId));
 
   return response.data.body;
 };
@@ -121,6 +166,28 @@ export const getMyPlans = async (params?: PagenationParams): Promise<PagenationR
   const response = await api.get<ApiResponse<PagenationResponse<Plan>>>(PLAN.MY_PLANS, {
     params,
   });
+
+  return response.data.body;
+};
+
+/**
+ * 여행에 이메일로 사용자 초대하기
+ * @param planId planId
+ * @returns
+ */
+export const inviteToMyPlan = async (planId: number, email: string): Promise<boolean> => {
+  const response = await api.post<ApiResponse<boolean>>(PLAN.INVITE(planId), { data: { email } });
+
+  return response.data.body;
+};
+
+/**
+ * 여행에서 나가기
+ * @param planId planId
+ * @returns
+ */
+export const leaveMyPlan = async (planId: number): Promise<boolean> => {
+  const response = await api.post<ApiResponse<boolean>>(PLAN.LEAVE(planId));
 
   return response.data.body;
 };

--- a/front_end/src/services/api/domains/plan/types.ts
+++ b/front_end/src/services/api/domains/plan/types.ts
@@ -82,7 +82,6 @@ export type PlanDetail = {
 
 export type CreatePlanRequest = UpdatePlanInfoRequest & UpdatePlanScheduleRequest;
 
-//TODO: 타입 일관화 필요
 export type PlanWriter = {
   id: number;
   name: string;
@@ -117,4 +116,15 @@ export type LockResponse = {
   userId: number;
   planId: number;
   lockStatus: boolean;
+};
+
+export type UpdateRouteRequest = {
+  routes: RouteInfo[];
+};
+
+export type RouteInfo = {
+  routeId: number;
+  dayIndex: number;
+  order: number;
+  deleted: boolean;
 };

--- a/front_end/src/services/api/domains/plan/types.ts
+++ b/front_end/src/services/api/domains/plan/types.ts
@@ -80,14 +80,7 @@ export type PlanDetail = {
   planWriters: Writer[];
 };
 
-export type CreatePlanRequest = {
-  title: string;
-  description: string;
-  tags: string[];
-  isPublic: boolean;
-  startDate: string;
-  endDate: string;
-};
+export type CreatePlanRequest = UpdatePlanInfoRequest & UpdatePlanScheduleRequest;
 
 //TODO: 타입 일관화 필요
 export type PlanWriter = {
@@ -101,23 +94,27 @@ export type PlanTag = {
   name: string;
 };
 
-export type CreatedPlanResponse = {
-  planId: number;
-  title: string;
-  description: string;
-  stella: string;
-  startDate: string;
-  endDate: string;
-  likeCount: number;
-  planWriters: PlanWriter[];
-  tags: PlanTag[];
-  isLiked: boolean;
-  isPublic: boolean;
-};
-
 export type PlanAttractionRequest = {
   dayIndex: number;
   attractionId: number;
   visitTime: string;
   memo: string;
+};
+
+export type UpdatePlanInfoRequest = {
+  title: string;
+  description: string;
+  isPublic: boolean;
+  tags: string[];
+};
+
+export type UpdatePlanScheduleRequest = {
+  startDate: string;
+  endDate: string;
+};
+
+export type LockResponse = {
+  userId: number;
+  planId: number;
+  lockStatus: boolean;
 };

--- a/front_end/src/services/api/endpoint.ts
+++ b/front_end/src/services/api/endpoint.ts
@@ -10,10 +10,14 @@ export const PLAN = {
   TAGS: 'v1/plans/tags',
   MY_PLANS: 'v1/user/plans',
   SCHEDULE: (planId: number) => `v1/plans/${planId}/schedule`,
-  ADD_ATTRACTIONS: (planId: number) => `v1/plans/${planId}/attraction`,
+  ATTRACTIONS: (planId: number) => `v1/plans/${planId}/attraction`,
   DETAIL: (planId: number) => `v1/plans/${planId}`,
   LIKE: (planId: number) => `v1/plans/${planId}/like`,
-  LOCK: (planId: number) => `v1/plans/${planId}/lock-check`,
+  LOCK_CHECK: (planId: number) => `v1/plans/${planId}/lock-check`,
+  LOCK: (planId: number) => `v1/plans/${planId}/lock`,
+  UNLOCK: (planId: number) => `v1/plans/${planId}/unlock`,
+  INVITE: (planId: number) => `v1/plans/${planId}/invite`,
+  LEAVE: (planId: number) => `v1/plans/${planId}/leave`,
 } as const;
 
 export const ATTRACTION = {

--- a/front_end/src/services/api/endpoint.ts
+++ b/front_end/src/services/api/endpoint.ts
@@ -8,9 +8,12 @@ export const AUTH = {
 export const PLAN = {
   PLANS: 'v1/plans',
   TAGS: 'v1/plans/tags',
+  MY_PLANS: 'v1/user/plans',
+  SCHEDULE: (planId: number) => `v1/plans/${planId}/schedule`,
   ADD_ATTRACTIONS: (planId: number) => `v1/plans/${planId}/attraction`,
   DETAIL: (planId: number) => `v1/plans/${planId}`,
   LIKE: (planId: number) => `v1/plans/${planId}/like`,
+  LOCK: (planId: number) => `v1/plans/${planId}/lock-check`,
 } as const;
 
 export const ATTRACTION = {

--- a/front_end/src/services/api/types.ts
+++ b/front_end/src/services/api/types.ts
@@ -24,3 +24,8 @@ export type PagenationResponse<T> = {
   first: boolean;
   last: boolean;
 };
+
+export type PagenationParams = {
+  page: number;
+  size: number;
+};

--- a/front_end/src/services/api/types.ts
+++ b/front_end/src/services/api/types.ts
@@ -25,7 +25,7 @@ export type PagenationResponse<T> = {
   last: boolean;
 };
 
-export type PagenationParams = {
+export type PaginationParams = {
   page: number;
   size: number;
 };

--- a/front_end/src/stores/plan.ts
+++ b/front_end/src/stores/plan.ts
@@ -1,16 +1,49 @@
 import { defineStore } from 'pinia';
 import { ref } from 'vue';
 import type { PlanDetail, RouteAttraction } from '@/services/api/domains/plan';
+import { fillPlanDetails } from '@/utils/planUtils';
 
 export const usePlanStore = defineStore('plan', () => {
   const currentPlan = ref<PlanDetail | null>(null);
+  const isModifying = ref<boolean>(false);
 
-  // 플랜 데이터 설정
+  /**
+   * 플랜 데이터를 설정하고 모든 초기화 작업을 수행합니다.
+   * @param plan - 설정할 플랜 데이터
+   */
   const setPlanDetail = (plan: PlanDetail | null) => {
-    currentPlan.value = plan;
+    if (!plan) {
+      currentPlan.value = null;
+      return;
+    }
+
+    // fillPlanDetails 유틸 함수를 사용하여 모든 날짜 채우기
+    const filledData = fillPlanDetails(plan);
+
+    // 초기화된 데이터 설정
+    currentPlan.value = filledData;
   };
 
-  // 특정 날짜에 여행지 추가
+  /**
+   * 수정 모드를 설정합니다.
+   * @param modifying - 수정 모드 여부
+   */
+  const setModifying = (modifying: boolean) => {
+    isModifying.value = modifying;
+  };
+
+  /**
+   * 수정 모드를 토글합니다.
+   */
+  const toggleModifying = () => {
+    isModifying.value = !isModifying.value;
+  };
+
+  /**
+   * 특정 날짜에 여행지를 추가합니다.
+   * @param date - 대상 날짜
+   * @param attraction - 추가할 여행지 정보
+   */
   const addAttractionToDate = (date: string, attraction: RouteAttraction) => {
     if (currentPlan.value?.details) {
       if (!currentPlan.value.details[date]) {
@@ -31,33 +64,95 @@ export const usePlanStore = defineStore('plan', () => {
     }
   };
 
-  // 특정 날짜의 여행지 제거
+  /**
+   * 특정 날짜의 여행지를 제거합니다.
+   * @param date - 대상 날짜
+   * @param routeId - 제거할 여행지의 ID
+   */
   const removeAttractionFromDate = (date: string, routeId: number) => {
     if (currentPlan.value?.details?.[date]) {
-      currentPlan.value.details[date] = currentPlan.value.details[date].filter(
+      const filteredAttractions = currentPlan.value.details[date].filter(
         attraction => attraction.routeId !== routeId
       );
+
+      // 제거 후 order 재정렬 (1부터 시작)
+      const reorderedAttractions = filteredAttractions.map((attraction, index) => ({
+        ...attraction,
+        order: index + 1,
+      }));
+
+      currentPlan.value.details[date] = reorderedAttractions;
     }
   };
 
-  // 여행지 순서 변경
+  /**
+   * 여행지 순서를 변경합니다.
+   * @param date - 대상 날짜
+   * @param attractions - 새로운 순서의 여행지 배열
+   */
   const reorderAttractions = (date: string, attractions: RouteAttraction[]) => {
     if (currentPlan.value?.details) {
-      currentPlan.value.details[date] = attractions;
+      // order 속성을 인덱스에 맞게 재정렬 (0번째 인덱스 = order: 1)
+      const reorderedAttractions = attractions.map((attraction, index) => ({
+        ...attraction,
+        order: index + 1,
+      }));
+
+      currentPlan.value.details[date] = reorderedAttractions;
     }
   };
 
-  // 플랜 초기화
+  /**
+   * 특정 날짜의 여행지를 order 기준으로 정렬합니다.
+   * @param date - 대상 날짜
+   */
+  const sortAttractionsByOrder = (date: string) => {
+    if (currentPlan.value?.details?.[date]) {
+      currentPlan.value.details[date].sort((a, b) => a.order - b.order);
+    }
+  };
+
+  /**
+   * 모든 날짜의 여행지 order를 재정렬합니다.
+   */
+  const normalizeAllOrders = () => {
+    if (currentPlan.value?.details) {
+      Object.keys(currentPlan.value.details).forEach(date => {
+        const attractions = currentPlan.value!.details![date];
+        const reorderedAttractions = attractions
+          .sort((a, b) => a.order - b.order) // 기존 order로 정렬
+          .map((attraction, index) => ({
+            ...attraction,
+            order: index + 1, // 새로운 order 할당
+          }));
+
+        currentPlan.value!.details![date] = reorderedAttractions;
+      });
+    }
+  };
+
+  /**
+   * 플랜을 초기화합니다.
+   */
   const clearPlan = () => {
     currentPlan.value = null;
+    isModifying.value = false;
   };
 
   return {
+    // State
     currentPlan,
+    isModifying,
+
+    // Actions
     setPlanDetail,
+    setModifying,
+    toggleModifying,
     addAttractionToDate,
     removeAttractionFromDate,
     reorderAttractions,
+    sortAttractionsByOrder,
+    normalizeAllOrders,
     clearPlan,
   };
 });

--- a/front_end/src/types/type.ts
+++ b/front_end/src/types/type.ts
@@ -1,7 +1,5 @@
-import type { AttractionContentType } from '@/constants/constant';
-
 export type User = {
-  id: string;
+  id: number;
   email: string;
   name: string;
 };
@@ -28,6 +26,3 @@ export type ConstellationData = {
   stars: Star[];
   connections: Connection[];
 };
-
-export type AttractionContentTypeCode = keyof typeof AttractionContentType;
-export type AttractionContentTypeValue = (typeof AttractionContentType)[AttractionContentTypeCode];

--- a/front_end/src/views/MyPlan.vue
+++ b/front_end/src/views/MyPlan.vue
@@ -11,287 +11,104 @@
       />
     </AsyncContainer>
 
-    <!-- 여행 계획 추가 다이얼로그 -->
-    <Dialog :open="isAddDialogOpen" @update:open="isAddDialogOpen = $event">
-      <DialogContent class="w-full max-w-lg border-0 bg-transparent p-0 shadow-none">
-        <div
-          class="relative overflow-hidden rounded-2xl border border-white/20 bg-white/10 backdrop-blur-md"
-        >
-          <!-- 그라데이션 오버레이 -->
-          <div
-            class="absolute inset-0 bg-gradient-to-br from-slate-900/80 via-purple-950/80 to-indigo-950/80"
-          />
-
-          <!-- 콘텐츠 -->
-          <div class="relative p-6">
-            <DialogHeader class="mb-6">
-              <DialogTitle class="text-2xl font-bold text-white">✨ 새로운 여행 계획</DialogTitle>
-            </DialogHeader>
-
-            <Form class="space-y-6" @submit="onSubmit">
-              <!-- 제목 입력 -->
-              <FormField v-slot="{ componentField }" name="title">
-                <FormItem>
-                  <FormLabel class="text-sm font-medium text-purple-200">제목</FormLabel>
-                  <FormControl>
-                    <Input
-                      v-bind="componentField"
-                      v-model="form.title"
-                      placeholder="어떤 여행을 계획하고 계신가요?"
-                      required
-                      class="border-white/20 bg-white/10 text-white backdrop-blur-sm transition-all duration-200 focus:border-purple-400/50 focus:bg-white/15 focus:ring-purple-400/30 [&::placeholder]:text-gray-400"
-                    />
-                  </FormControl>
-                  <FormMessage class="text-red-300" />
-                </FormItem>
-              </FormField>
-
-              <!-- 설명 입력 -->
-              <FormField v-slot="{ componentField }" name="description">
-                <FormItem>
-                  <FormLabel class="text-sm font-medium text-purple-200">설명</FormLabel>
-                  <FormControl>
-                    <Textarea
-                      v-bind="componentField"
-                      v-model="form.description"
-                      placeholder="여행에 대한 간단한 설명을 적어주세요"
-                      required
-                      rows="3"
-                      class="resize-none border-white/20 bg-white/10 text-white backdrop-blur-sm transition-all duration-200 focus:border-purple-400/50 focus:bg-white/15 focus:ring-purple-400/30 [&::placeholder]:text-gray-400"
-                    />
-                  </FormControl>
-                  <FormMessage class="text-red-300" />
-                </FormItem>
-              </FormField>
-
-              <!-- 태그 입력 -->
-              <FormField v-slot="{ componentField }" name="tags">
-                <FormItem>
-                  <FormLabel class="text-sm font-medium text-purple-200">태그</FormLabel>
-                  <FormControl>
-                    <Input
-                      v-bind="componentField"
-                      v-model="tagInput"
-                      placeholder="태그를 쉼표로 구분해서 입력해주세요 (예: 힐링, 자연, 맛집)"
-                      class="border-white/20 bg-white/10 text-white backdrop-blur-sm transition-all duration-200 focus:border-purple-400/50 focus:bg-white/15 focus:ring-purple-400/30 [&::placeholder]:text-gray-400"
-                    />
-                  </FormControl>
-                  <FormDescription class="text-xs text-purple-200/70">
-                    쉼표로 구분하여 여러 태그를 입력할 수 있습니다
-                  </FormDescription>
-                  <FormMessage class="text-red-300" />
-                </FormItem>
-              </FormField>
-
-              <!-- 날짜 범위 선택 -->
-              <FormField name="dateRange">
-                <FormItem class="flex flex-col">
-                  <FormLabel class="text-sm font-medium text-purple-200">여행 기간</FormLabel>
-                  <Popover>
-                    <PopoverTrigger asChild>
-                      <FormControl>
-                        <Button
-                          variant="outline"
-                          :class="[
-                            'w-full justify-start border-white/20 bg-white/10 text-left font-normal text-white backdrop-blur-sm transition-all duration-200 hover:border-purple-400/50 hover:bg-white/15 focus:border-purple-400/50 focus:ring-purple-400/30',
-                            (!form.startDate || !form.endDate) && 'text-gray-400',
-                          ]"
-                        >
-                          <CalendarIcon class="mr-2 h-4 w-4 text-purple-400" />
-                          <span v-if="form.startDate && form.endDate">
-                            {{ formatDateValue(dateRange.start) }} ~
-                            {{ formatDateValue(dateRange.end) }}
-                          </span>
-                          <span v-else-if="form.startDate">
-                            {{ formatDateValue(dateRange.start) }} ~ 종료일 선택
-                          </span>
-                          <span v-else>여행 날짜를 선택해주세요</span>
-                        </Button>
-                      </FormControl>
-                    </PopoverTrigger>
-                    <PopoverContent class="w-auto border-white/20 bg-white/10 p-0 backdrop-blur-md">
-                      <RangeCalendar
-                        v-model="dateRange"
-                        class="rounded-md border-0 bg-transparent text-white [&_[role=gridcell]]:text-white [&_[role=gridcell]:hover]:bg-white/20 [&_[role=gridcell][data-range-middle]]:bg-purple-300/50 [&_[role=gridcell][data-selected]]:bg-purple-500 [&_[role=gridcell][data-selected]]:text-white [&_button]:text-white [&_button:hover]:bg-white/20"
-                        :numberOfMonths="2"
-                        @update:modelValue="handleDateRangeChange"
-                      />
-                    </PopoverContent>
-                  </Popover>
-                  <FormDescription class="text-xs text-purple-200/70">
-                    시작일과 종료일을 선택해주세요
-                  </FormDescription>
-                  <FormMessage class="text-red-300" />
-                </FormItem>
-              </FormField>
-
-              <!-- 공개 설정 -->
-              <FormField name="isPublic">
-                <FormItem class="flex flex-row items-start space-y-0 space-x-3">
-                  <FormControl>
-                    <Checkbox
-                      :checked="form.isPublic"
-                      class="border-white/20 bg-white/10 text-purple-400 focus:ring-purple-400/30 data-[state=checked]:border-purple-500 data-[state=checked]:bg-purple-500"
-                      @update:checked="form.isPublic = $event"
-                    />
-                  </FormControl>
-                  <div class="space-y-1 leading-none">
-                    <FormLabel class="cursor-pointer text-sm font-medium text-purple-200">
-                      다른 사람들과 공유하기
-                    </FormLabel>
-                    <FormDescription class="text-xs text-purple-200/70">
-                      공개로 설정하면 다른 사용자들도 회원님의 여행 계획을 볼 수 있습니다
-                    </FormDescription>
-                  </div>
-                </FormItem>
-              </FormField>
-
-              <!-- 버튼들 -->
-              <div class="flex justify-end gap-3 pt-4">
-                <Button
-                  type="button"
-                  variant="ghost"
-                  class="border border-white/20 bg-white/10 text-white backdrop-blur-sm hover:border-white/30 hover:bg-white/20 focus:ring-white/30"
-                  @click="isAddDialogOpen = false"
-                >
-                  취소
-                </Button>
-                <Button
-                  type="submit"
-                  :disabled="isSubmitting"
-                  class="bg-gradient-to-r from-purple-500 to-indigo-500 font-medium text-white shadow-lg shadow-purple-500/25 hover:from-purple-600 hover:to-indigo-600 focus:ring-purple-400/50 disabled:opacity-50"
-                >
-                  <LoaderCircle v-if="isSubmitting" class="mr-2 h-4 w-4 animate-spin" />
-                  <span v-if="isSubmitting">추가 중...</span>
-                  <span v-else>✨ 계획 추가</span>
-                </Button>
-              </div>
-            </Form>
-          </div>
-        </div>
-      </DialogContent>
-    </Dialog>
+    <!-- 여행 계획 추가 모달 -->
+    <PlanFormModal
+      :isOpen="isAddDialogOpen"
+      :isEditMode="false"
+      :initialData="null"
+      :isSubmitting="isSubmitting"
+      @update:open="isAddDialogOpen = $event"
+      @submit="handlePlanSubmit"
+    />
   </section>
 </template>
 
 <script setup lang="ts">
-import { ref, type Ref } from 'vue';
+import { ref } from 'vue';
 import { useRouter } from 'vue-router';
 import { toast } from 'vue-sonner';
-import { CalendarIcon, LoaderCircle } from 'lucide-vue-next';
-import { type DateValue, getLocalTimeZone, today } from '@internationalized/date';
 import AsyncContainer from '@/components/AsyncContainer/AsyncContainer.vue';
 import { FilteredPlansSkeleton, FilteredPlansError } from '@/components/views/plan/FilteredPlans';
-import { type Plan, type Tag, createPlan } from '@/services/api/domains/plan';
+import PlanFormModal from '@/components/views/plan/PlanFormModal.vue';
+import {
+  type Plan,
+  type Tag,
+  createPlan,
+  type CreatePlanRequest,
+} from '@/services/api/domains/plan';
 import { ROUTES } from '@/router/routes';
 import MyPlans from '@/components/views/myPlan/myPlans/myPlans.vue';
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Textarea } from '@/components/ui/textarea';
-import { Checkbox } from '@/components/ui/checkbox';
-import { RangeCalendar } from '@/components/ui/range-calendar';
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
-import {
-  Form,
-  FormControl,
-  FormDescription,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from '@/components/ui/form';
-import type { DateRange } from 'reka-ui';
 
 const router = useRouter();
 const scrollContainerRef = ref<HTMLElement | null>(null);
 const isAddDialogOpen = ref(false);
 const isSubmitting = ref(false);
-const start = today(getLocalTimeZone());
-const end = start.add({ days: 7 });
 
-// 날짜 포맷팅 함수
-const formatDateValue = (dateValue: DateValue | undefined) => {
-  if (!dateValue) return '';
-  return `${dateValue.month}월 ${dateValue.day}일`;
-};
-
-const dateRange = ref({
-  start,
-  end,
-}) as Ref<DateRange>;
-
-const dateValueToString = (dateValue: DateValue | undefined): string => {
-  if (!dateValue) return '';
-  return `${dateValue.year}-${String(dateValue.month).padStart(2, '0')}-${String(dateValue.day).padStart(2, '0')}`;
-};
-
-// 날짜 범위 변경 핸들러
-const handleDateRangeChange = (range: {
-  start: DateValue | undefined;
-  end: DateValue | undefined;
-}) => {
-  dateRange.value = range;
-
-  form.value.startDate = dateValueToString(range.start);
-  form.value.endDate = dateValueToString(range.end);
-};
-
-// 여행 계획 다이얼로그 상태
-const form = ref({
-  title: '',
-  description: '',
-  tags: [] as string[],
-  isPublic: true,
-  startDate: '',
-  endDate: '',
-});
-const tagInput = ref('');
-
-// 핸들러들
+/**
+ * 플랜 카드 클릭 핸들러 - 플랜 수정 페이지로 이동
+ * @param plan - 클릭된 플랜 정보
+ */
 const handlePlanCardClick = (plan: Plan) => {
   router.push({
-    name: ROUTES.PLAN_DETAIL.name,
+    name: ROUTES.PLAN_MODIFY.name,
     params: { planId: plan.planId.toString() },
   });
 };
 
+/**
+ * 플랜 추가 카드 클릭 핸들러 - 모달 열기
+ */
 const handleAddPlanCardClick = () => {
   isAddDialogOpen.value = true;
 };
 
+/**
+ * 플랜 좋아요 클릭 핸들러
+ * @param plan - 좋아요한 플랜 정보
+ */
 const handlePlanLikeClick = (plan: Plan) => {
   console.log('여행 계획 좋아요 클릭:', plan.title);
+  // TODO: 좋아요 API 호출
 };
 
+/**
+ * 플랜 태그 클릭 핸들러
+ * @param tag - 클릭된 태그 정보
+ */
 const handlePlanTagClick = (tag: Tag) => {
   console.log('여행 계획 태그 클릭:', tag.name);
+  // TODO: 태그 필터링 기능
 };
 
-const onSubmit = async () => {
+/**
+ * 플랜 생성/수정 제출 핸들러
+ * @param formData - 폼에서 제출된 데이터
+ */
+const handlePlanSubmit = async (formData: CreatePlanRequest) => {
   if (isSubmitting.value) return;
 
   try {
     isSubmitting.value = true;
-    form.value.tags = tagInput.value
-      .split(',')
-      .map(t => t.trim())
-      .filter(t => t.length > 0);
 
-    const plan = await createPlan(form.value);
+    // 새 플랜 생성
+    const plan = await createPlan(formData);
 
     toast.success('여행 계획이 성공적으로 추가되었습니다!', {
-      description: `${form.value.title} 계획이 생성되었습니다.`,
+      description: `${formData.title} 계획이 생성되었습니다.`,
       duration: 4000,
     });
 
+    // 생성된 플랜의 수정 페이지로 이동
     router.push({
       name: ROUTES.PLAN_MODIFY.name,
-      params: { planId: plan.planId },
+      params: { planId: plan.planId.toString() },
       state: { plan },
     });
-  } catch (err) {
-    console.error(err);
+
+    // 모달 닫기
+    isAddDialogOpen.value = false;
+  } catch (error) {
+    console.error('계획 추가 실패:', error);
 
     toast.error('계획 추가에 실패했습니다', {
       description: '잠시 후 다시 시도해주세요.',

--- a/front_end/src/views/PlanAttractionSearch.vue
+++ b/front_end/src/views/PlanAttractionSearch.vue
@@ -67,8 +67,8 @@
   </section>
 </template>
 <script setup lang="ts">
-import { ref, computed, reactive } from 'vue';
-import { useRouter, useRoute } from 'vue-router';
+import { ref, reactive } from 'vue';
+import { useRouter } from 'vue-router';
 import { ArrowLeft } from 'lucide-vue-next';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -84,17 +84,15 @@ import { getAttractions } from '@/services/api/domains/attraction';
 import { useScroll } from '@/composables/useScroll';
 import { useMapState } from '@/composables/useMapState';
 
-const props = defineProps<{
+defineProps<{
   currentDate?: string | null;
 }>();
 
 const filterComponentRef = ref<InstanceType<typeof AttractionFilter> | null>(null);
 
 const router = useRouter();
-const route = useRoute();
 
 // 쿼리에서 날짜 가져오기
-const selectedDate = computed(() => props.currentDate || (route.query.date as string) || null);
 const attractions = ref<Attraction[]>([]);
 const scrollContainerRef = ref<HTMLElement | null>(null);
 const { isScrollingDown, scrollY, handleScroll } = useScroll();

--- a/front_end/src/views/PlanAttractionSearch.vue
+++ b/front_end/src/views/PlanAttractionSearch.vue
@@ -67,7 +67,7 @@
   </section>
 </template>
 <script setup lang="ts">
-import { ref, reactive } from 'vue';
+import { ref, reactive, onUnmounted } from 'vue';
 import { useRouter } from 'vue-router';
 import { ArrowLeft } from 'lucide-vue-next';
 import { Button } from '@/components/ui/button';
@@ -117,6 +117,10 @@ const handleFilterChange = (filters: AttractionsParams) => {
   filterParams.size = filters.size;
   fetchAttractions();
 };
+
+onUnmounted(() => {
+  closeFilterPanel();
+});
 
 const closeFilterPanel = () => {
   if (filterComponentRef.value) {

--- a/front_end/src/views/PlanAttractionSearch.vue
+++ b/front_end/src/views/PlanAttractionSearch.vue
@@ -83,16 +83,11 @@ import type { Attraction, AttractionsParams } from '@/services/api/domains/attra
 import { getAttractions } from '@/services/api/domains/attraction';
 import { useScroll } from '@/composables/useScroll';
 import { useMapState } from '@/composables/useMapState';
-import { toast } from 'vue-sonner';
 
 const props = defineProps<{
   currentDate?: string | null;
 }>();
 
-// Emits
-const emit = defineEmits<{
-  addAttraction: [attraction: Attraction, date: string];
-}>();
 const filterComponentRef = ref<InstanceType<typeof AttractionFilter> | null>(null);
 
 const router = useRouter();

--- a/front_end/src/views/PlanDetail.vue
+++ b/front_end/src/views/PlanDetail.vue
@@ -1,26 +1,52 @@
 <template>
   <div class="h-full overflow-y-auto">
-    <div class="flex items-center border-b border-white/20 bg-slate-900/80 p-2">
+    <div class="flex items-center justify-between border-b border-white/20 bg-slate-900/80 p-2">
+      <div class="flex items-center">
+        <Button
+          variant="ghost"
+          size="icon"
+          class="mr-2 h-8 w-8 text-gray-300 hover:bg-white/10 hover:text-white"
+          @click="goBack"
+        >
+          <ChevronLeft class="h-5 w-5" />
+        </Button>
+        <h3 class="text-lg font-semibold text-white">여행 계획 상세</h3>
+      </div>
+
       <Button
-        variant="ghost"
-        size="icon"
-        class="mr-2 h-8 w-8 text-gray-300 hover:bg-white/10 hover:text-white"
-        @click="goBack"
+        variant="outline"
+        size="sm"
+        class="border-purple-500/50 bg-purple-900/30 text-purple-300 hover:bg-purple-800/50 hover:text-purple-200"
+        @click="handleTogglePlanInfoEdit"
       >
-        <ChevronLeft class="h-5 w-5" />
+        계획 정보 수정
       </Button>
-      <h3 class="text-lg font-semibold text-white">여행 계획 상세</h3>
     </div>
 
     <AsyncContainer :loadingComponent="PlanDetailSkeleton" :errorComponent="PlanDetailError">
-      <PlanDetail :planId="planId" @moveToAttractionSearch="handleMoveToAttractionSearch" />
+      <PlanDetail
+        :planId="planId"
+        @moveToAttractionSearch="handleMoveToAttractionSearch"
+        @toggleScheduleEdit="handleToggleScheduleEdit"
+      />
     </AsyncContainer>
+
+    <!-- 여행 계획 정보 수정 모달 -->
+    <PlanFormModal
+      :isOpen="isPlanInfoEditOpen"
+      :isEditMode="true"
+      :initialData="planStore.currentPlan"
+      :isSubmitting="isSubmittingEdit"
+      @update:open="isPlanInfoEditOpen = $event"
+      @submit="handlePlanInfoSubmit"
+    />
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
 import { useRouter, useRoute } from 'vue-router';
+import { toast } from 'vue-sonner';
 import { ChevronLeft } from 'lucide-vue-next';
 import AsyncContainer from '@/components/AsyncContainer/AsyncContainer.vue';
 import { Button } from '@/components/ui/button';
@@ -29,25 +55,126 @@ import {
   PlanDetailSkeleton,
   PlanDetail,
 } from '@/components/views/plan/PlanDetail';
-import { ROUTES } from '@/router/routes';
+import PlanFormModal from '@/components/views/plan/PlanFormModal.vue';
+import { usePlanStore } from '@/stores/plan';
+import {
+  updatePlanInfo,
+  updatePlanSchedule,
+  checkLock,
+  type CreatePlanRequest,
+  type UpdatePlanInfoRequest,
+  type UpdatePlanScheduleRequest,
+} from '@/services/api/domains/plan';
 
 // Vue Router
 const router = useRouter();
 const route = useRoute();
+const planStore = usePlanStore();
 
 // planId 계산 속성
 const planId = computed(() => Number(route.params.planId));
+
+// 상태 관리
+const isPlanInfoEditOpen = ref(false);
+const isSubmittingEdit = ref(false);
 
 const emit = defineEmits<{
   (e: 'moveToAttractionSearch', date: string): void;
 }>();
 
-// 여행지 추가 버튼 클릭 핸들러
+/**
+ * 여행지 추가 버튼 클릭 핸들러
+ * @param date - 선택된 날짜
+ */
 const handleMoveToAttractionSearch = (date: string) => {
   emit('moveToAttractionSearch', date);
 };
-// 뒤로 가기
+
+/**
+ * 일정 편집 모드 토글
+ */
+const handleToggleScheduleEdit = () => {
+  planStore.toggleModifying();
+};
+
+/**
+ * 여행계획 정보 수정 모달 열기
+ */
+const handleTogglePlanInfoEdit = () => {
+  isPlanInfoEditOpen.value = true;
+};
+
+/**
+ * 여행계획 정보 수정 제출 핸들러
+ * @param formData - 수정된 폼 데이터
+ */
+const handlePlanInfoSubmit = async (formData: CreatePlanRequest) => {
+  if (isSubmittingEdit.value || !planStore.currentPlan) return;
+
+  try {
+    isSubmittingEdit.value = true;
+
+    const originalPlan = planStore.currentPlan;
+
+    // 일정 정보가 변경되었는지 확인
+    const isScheduleChanged =
+      formData.startDate !== originalPlan.startDate || formData.endDate !== originalPlan.endDate;
+
+    if (isScheduleChanged) {
+      // 일정 변경 시 락 확인
+      const lockResponse = await checkLock(originalPlan.planId);
+
+      if (lockResponse.lockStatus && lockResponse.userId !== originalPlan.planWriters[0]?.userId) {
+        toast.error('다른 사용자가 수정 중입니다', {
+          description: '잠시 후 다시 시도해주세요.',
+          duration: 4000,
+        });
+        return;
+      }
+
+      // 일정 정보 업데이트 (락 확인 필요)
+      const scheduleData: UpdatePlanScheduleRequest = {
+        startDate: formData.startDate,
+        endDate: formData.endDate,
+      };
+
+      await updatePlanSchedule(originalPlan.planId, scheduleData);
+    }
+
+    // 기본 정보 업데이트 (락 확인 불필요)
+    const infoData: UpdatePlanInfoRequest = {
+      title: formData.title,
+      description: formData.description,
+      tags: formData.tags,
+      isPublic: formData.isPublic,
+    };
+
+    const updatedPlanResponse = await updatePlanInfo(originalPlan.planId, infoData);
+
+    planStore.setPlanDetail(updatedPlanResponse);
+
+    toast.success('여행 계획이 성공적으로 수정되었습니다!', {
+      description: `${formData.title} 계획이 업데이트되었습니다.`,
+      duration: 4000,
+    });
+
+    isPlanInfoEditOpen.value = false;
+  } catch (error) {
+    console.error('계획 수정 실패:', error);
+
+    toast.error('계획 수정에 실패했습니다', {
+      description: '잠시 후 다시 시도해주세요.',
+      duration: 4000,
+    });
+  } finally {
+    isSubmittingEdit.value = false;
+  }
+};
+
+/**
+ * 뒤로 가기
+ */
 const goBack = () => {
-  router.push({ name: ROUTES.PLANS.name });
+  router.back();
 };
 </script>

--- a/front_end/src/views/PlanDetail.vue
+++ b/front_end/src/views/PlanDetail.vue
@@ -13,7 +13,7 @@
     </div>
 
     <AsyncContainer :loadingComponent="PlanDetailSkeleton" :errorComponent="PlanDetailError">
-      <PlanDetail :planId="planId" />
+      <PlanDetail :planId="planId" @moveToAttractionSearch="handleMoveToAttractionSearch" />
     </AsyncContainer>
   </div>
 </template>
@@ -38,6 +38,14 @@ const route = useRoute();
 // planId 계산 속성
 const planId = computed(() => Number(route.params.planId));
 
+const emit = defineEmits<{
+  (e: 'moveToAttractionSearch', date: string): void;
+}>();
+
+// 여행지 추가 버튼 클릭 핸들러
+const handleMoveToAttractionSearch = (date: string) => {
+  emit('moveToAttractionSearch', date);
+};
 // 뒤로 가기
 const goBack = () => {
   router.push({ name: ROUTES.PLANS.name });

--- a/front_end/src/views/PlanDetail.vue
+++ b/front_end/src/views/PlanDetail.vue
@@ -14,6 +14,7 @@
       </div>
 
       <Button
+        v-if="isModifyPage"
         variant="outline"
         size="sm"
         class="border-purple-500/50 bg-purple-900/30 text-purple-300 hover:bg-purple-800/50 hover:text-purple-200"
@@ -24,11 +25,7 @@
     </div>
 
     <AsyncContainer :loadingComponent="PlanDetailSkeleton" :errorComponent="PlanDetailError">
-      <PlanDetail
-        :planId="planId"
-        @moveToAttractionSearch="handleMoveToAttractionSearch"
-        @toggleScheduleEdit="handleToggleScheduleEdit"
-      />
+      <PlanDetail :planId="planId" @moveToAttractionSearch="handleMoveToAttractionSearch" />
     </AsyncContainer>
 
     <!-- 여행 계획 정보 수정 모달 -->
@@ -65,10 +62,18 @@ import {
   type UpdatePlanInfoRequest,
   type UpdatePlanScheduleRequest,
 } from '@/services/api/domains/plan';
+import { ROUTES } from '@/router/routes';
+
+const route = useRoute();
+/**
+ * 현재 라우트가 편집 화면인지 확인
+ */
+const isModifyPage = computed(() => {
+  return route.name === ROUTES.PLAN_MODIFY.name;
+});
 
 // Vue Router
 const router = useRouter();
-const route = useRoute();
 const planStore = usePlanStore();
 
 // planId 계산 속성
@@ -88,13 +93,6 @@ const emit = defineEmits<{
  */
 const handleMoveToAttractionSearch = (date: string) => {
   emit('moveToAttractionSearch', date);
-};
-
-/**
- * 일정 편집 모드 토글
- */
-const handleToggleScheduleEdit = () => {
-  planStore.toggleModifying();
 };
 
 /**

--- a/front_end/src/views/PlanDetail.vue
+++ b/front_end/src/views/PlanDetail.vue
@@ -63,6 +63,9 @@ import {
   type UpdatePlanScheduleRequest,
 } from '@/services/api/domains/plan';
 import { ROUTES } from '@/router/routes';
+import { useAuthStore } from '@/stores/auth';
+
+const authStore = useAuthStore();
 
 const route = useRoute();
 /**
@@ -122,7 +125,7 @@ const handlePlanInfoSubmit = async (formData: CreatePlanRequest) => {
       // 일정 변경 시 락 확인
       const lockResponse = await checkLock(originalPlan.planId);
 
-      if (lockResponse.lockStatus && lockResponse.userId !== originalPlan.planWriters[0]?.userId) {
+      if (lockResponse.lockStatus && lockResponse.userId !== authStore.user?.id) {
         toast.error('다른 사용자가 수정 중입니다', {
           description: '잠시 후 다시 시도해주세요.',
           duration: 4000,

--- a/front_end/src/views/PlanModify.vue
+++ b/front_end/src/views/PlanModify.vue
@@ -8,16 +8,7 @@
             <component :is="Component" :currentDate="selectedDate" />
           </template>
           <template v-else>
-            <AsyncContainer
-              :loadingComponent="PlanDetailSkeleton"
-              :errorComponent="PlanDetailError"
-            >
-              <PlanDetail
-                :planId="planId"
-                class="h-full overflow-x-hidden overflow-y-auto"
-                @addAttraction="handleMoveToAttractionSearch"
-              />
-            </AsyncContainer>
+            <PlanDetail @moveToAttractionSearch="handleMoveToAttractionSearch" />
           </template>
         </router-view>
       </ResizablePanel>
@@ -65,15 +56,11 @@ import AsyncContainer from '@/components/AsyncContainer/AsyncContainer.vue';
 import MapContainer from '@/components/map/MapContainer.vue';
 import MapError from '@/components/map/MapError.vue';
 import {
-  PlanDetailError,
-  PlanDetailSkeleton,
-  PlanDetail,
-} from '@/components/views/plan/PlanDetail';
-import {
   AttractionDetail,
   AttractionDetailError,
   AttractionDetailSkeleton,
 } from '@/components/views/attraction/AttractionDetail';
+import PlanDetail from '@/views/PlanDetail.vue';
 import CommonSkeleton from '@/components/skeleton/CommonSkeleton/CommonSkeleton.vue';
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from '@/components/ui/resizable';
 import { usePlanStore } from '@/stores/plan';

--- a/front_end/src/views/PlanModify.vue
+++ b/front_end/src/views/PlanModify.vue
@@ -50,7 +50,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue';
+import { computed, onUnmounted, ref } from 'vue';
 import { useRouter, useRoute } from 'vue-router';
 import AsyncContainer from '@/components/AsyncContainer/AsyncContainer.vue';
 import MapContainer from '@/components/map/MapContainer.vue';
@@ -76,23 +76,37 @@ const { mapRef, mapLevel, mapCenter, selectedAttraction } = useMapState();
 const planId = computed(() => Number(route.params.planId));
 const selectedDate = ref<string | null>(null);
 
+onUnmounted(() => {
+  planStore.clearPlan();
+});
+
+/**
+ * 지도 리사이즈 처리
+ */
 const handleMapResize = () => {
   if (mapRef.value) {
     mapRef.value.refreshMap();
   }
 };
 
+/**
+ * 여행지 검색 화면으로 이동
+ * @param date - 선택된 날짜
+ */
 const handleMoveToAttractionSearch = (date: string) => {
   selectedDate.value = date;
 
   router.push({
     name: ROUTES.PLAN_MODIFY_ATTRACTION.name,
     params: { planId: planId.value },
-    query: { date },
+    query: { date: date },
   });
 };
 
-// 여행지 추가 핸들러
+/**
+ * 여행지 추가 처리
+ * @param attractionId - 추가할 여행지 ID
+ */
 const handleAddAttraction = async (attractionId: number) => {
   if (!selectedDate.value || !planStore.currentPlan?.startDate) {
     throw new Error('필수 날짜 정보가 없습니다.');
@@ -116,7 +130,12 @@ const handleAddAttraction = async (attractionId: number) => {
   router.back();
 };
 
-// dayIndex 계산 함수
+/**
+ * dayIndex 계산 함수
+ * @param selectedDate - 선택된 날짜
+ * @param planStartDate - 여행 시작 날짜
+ * @returns dayIndex (1부터 시작)
+ */
 function calculateDayIndex(selectedDate: string, planStartDate: string): number {
   if (!selectedDate || !planStartDate) {
     throw new Error('날짜 값이 유효하지 않습니다');
@@ -135,7 +154,9 @@ function calculateDayIndex(selectedDate: string, planStartDate: string): number 
   return dayDiff + 1;
 }
 
-// 여행지 상세 사이드바 닫기
+/**
+ * 여행지 상세 사이드바 닫기
+ */
 const closeAttractionDetail = () => {
   selectedAttraction.value = null;
 };

--- a/front_end/src/views/PlanModify.vue
+++ b/front_end/src/views/PlanModify.vue
@@ -96,7 +96,6 @@ const handleMoveToAttractionSearch = (date: string) => {
 const handleAddAttraction = async (attractionId: number) => {
   if (!selectedDate.value || !planStore.currentPlan?.startDate) {
     throw new Error('필수 날짜 정보가 없습니다.');
-    return;
   }
   const dayIndex = calculateDayIndex(selectedDate.value, planStore.currentPlan?.startDate);
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #73 

## 📝 작업 내용
- [x] 여행 계획 수정 화면 UI 구현
- [x] 드래그 앤 드롭으로 여행지 순서 변경 기능
- [x] 여행지 추가/삭제 기능
- [x] 여행 계획 정보 수정 모달
- [x] 초대 기능 및 락 시스템 구현

## 📑 작업 상세 내용

### 주요 변경사항
- `vuedraggable` 패키지 추가하여 드래그 앤 드롭 기능 구현
- `DailyScheduleCard`에 드래그 가능한 여행지 목록 추가
- `AttractionItem`에 드래그 핸들 및 삭제 버튼 추가
- `PlanFormModal` 컴포넌트로 계획 정보 수정 기능
- `ConfirmModal`, `InviteModal` 추가하여 협업 기능 지원

### API 연동
- 여행 계획 수정 API (`updatePlanInfo`, `updatePlanSchedule`)
- 경로 수정 API (`updateRoute`)
- 락 관리 API (`checkLock`, `getLock`, `returnLock`)
- 초대 기능 API (`inviteToMyPlan`)

### Store 개선
- `usePlanStore`에 수정 모드 상태 관리
- 변경된 데이터 추적 및 락 상태 관리
- 드래그 앤 드롭 순서 변경 처리

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 여행 일정 카드에서 드래그 앤 드롭으로 명소 순서 변경 및 삭제 기능이 추가되었습니다.
  - 여행 계획 초대 및 초대 관리, 계획 탈퇴, 일정 편집 잠금 등 협업 기능이 도입되었습니다.
  - 여행 계획 생성/수정, 초대, 탈퇴, 일정 편집 등에 다양한 모달 UI가 추가되었습니다.
  - 여행 계획 정보 수정이 별도 모달로 분리되어 편리하게 관리할 수 있습니다.

- **개선 및 변경**
  - 일정 편집 시 동시 편집 방지를 위한 잠금 관리가 적용되었습니다.
  - 여행 계획 상세, 내 여행, 일정 검색 등에서 UI 및 사용성 개선이 이루어졌습니다.
  - 내 여행 목록 조회가 사용자별로 변경되었으며, 일정 추가 UI가 모달 컴포넌트로 통합되었습니다.
  - 일정 카드 클릭 이벤트가 조건 없이 항상 발생하도록 수정되었습니다.

- **버그 수정**
  - 일정 카드 클릭 이벤트가 조건 없이 항상 발생하도록 수정되었습니다.

- **기타**
  - API 연동 범위가 확장되어 내 여행 목록, 초대, 탈퇴, 잠금 관리 등이 지원됩니다.
  - 내부 상태 및 스토어 구조가 일정 변경 이력과 삭제 내역을 추적하도록 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->