### PR TITLE
[FE-FEAT] 메인화면, 여행지, 여행 계획 페이지 api 연동

### DIFF
--- a/front_end/src/components/NavigationBar/NavigationBar.vue
+++ b/front_end/src/components/NavigationBar/NavigationBar.vue
@@ -59,7 +59,6 @@ const menuItems = computed(() => {
   const navigationItems = [
     { name: '여행계획', icon: Map, route: ROUTES.PLANS.path },
     { name: '여행지', icon: Compass, route: ROUTES.ATTRACTION.path },
-    { name: '내여행계획', icon: Compass, route: ROUTES.MY_PLANS.path },
   ];
 
   return navigationItems;
@@ -141,6 +140,21 @@ const handleModalOpen = (value: '' | 'login' | 'register') => {
           >
             <!-- <component :is="item.icon" class="h-5 w-5" /> -->
             <span>{{ item.name }}</span>
+          </button>
+        </template>
+
+        <template v-if="isLoggedIn">
+          <button
+            class="group relative flex items-center gap-3 text-sm font-medium tracking-widest uppercase transition-all duration-300"
+            :class="[
+              isActiveRoute(ROUTES.MY_PLANS.path)
+                ? 'text-purple-400'
+                : 'text-gray-300 hover:text-purple-200',
+            ]"
+            @click="handleRoute(ROUTES.MY_PLANS.path)"
+          >
+            <!-- <component :is="item.icon" class="h-5 w-5" /> -->
+            <span>내여행계획</span>
           </button>
         </template>
         <!-- User Account Dropdown -->

--- a/front_end/src/components/common/Tag/Tag.vue
+++ b/front_end/src/components/common/Tag/Tag.vue
@@ -23,7 +23,7 @@ const handleClick = () => {
     tabindex="0"
     class="cursor-pointer rounded-full border-0 px-3 py-1.5 text-xs transition-colors hover:opacity-80"
     :class="isOverflow ? 'bg-gray-600/30 text-gray-300' : 'bg-purple-500/30 text-purple-200'"
-    @click="handleClick"
+    @click.stop="handleClick"
     @keydown.enter="handleClick"
   >
     {{ label }}

--- a/front_end/src/components/views/main/AttractionsSection/AttractionsSection.vue
+++ b/front_end/src/components/views/main/AttractionsSection/AttractionsSection.vue
@@ -1,19 +1,20 @@
 <script setup lang="ts">
-import { ref, watch } from 'vue';
+import { ref } from 'vue';
 import RowCardListContainer from '@/components/common/RowCardListContainer/RowCardListContainer.vue';
 import AttractionCard from '@/components/card/AttractionCard/AttractionCard.vue';
-import { getAttractions, type Attraction } from '@/services/api/domains/attraction';
-import type { AttractionsParams } from '@/services/api/domains/attraction';
+import { getFeaturedAttractions } from '@/services/api/domains/attraction';
+import { type Attraction } from '@/services/api/domains/attraction/types';
+import { ContentTypeId } from '@/constants/constant';
 
 interface Props {
   title: string;
-  apiParams?: AttractionsParams;
   showMoreButton?: boolean;
+  contentType?: number;
 }
 
 const props = withDefaults(defineProps<Props>(), {
-  apiParams: () => ({ page: 1, size: 10 }),
   showMoreButton: true,
+  contentType: ContentTypeId.ACCOMMODATION,
 });
 
 const emit = defineEmits<{
@@ -26,17 +27,11 @@ const emit = defineEmits<{
 const attractions = ref<Attraction[]>([]);
 
 const fetchAttractions = async () => {
-  const response = await getAttractions(props.apiParams);
-  attractions.value = response.content;
+  const response = await getFeaturedAttractions(props.contentType);
+  attractions.value = response.featuredAttractions;
 };
 
 await fetchAttractions();
-
-watch(
-  () => props.apiParams,
-  () => fetchAttractions(),
-  { deep: true }
-);
 </script>
 
 <template>

--- a/front_end/src/components/views/main/PopularTagsSection/PopularTagsSection.vue
+++ b/front_end/src/components/views/main/PopularTagsSection/PopularTagsSection.vue
@@ -7,7 +7,9 @@
 <script setup lang="ts">
 import GridCardListContainer from '@/components/common/GridCardListContainer/GridCardListContainer.vue';
 import TagCard from '@/components/card/TagCard/TagCard.vue';
-import { getPopularTags, type Tag } from '@/services/api/domains/plan';
+import { type FeaturedTags, type Tag } from '@/services/api/domains/plan';
+import { getPopularTags } from '@/services/api/domains/attraction';
 
-const tags: Tag[] = await getPopularTags();
+const featuredTages: FeaturedTags = await getPopularTags();
+const tags: Tag[] = featuredTages.featuredTags;
 </script>

--- a/front_end/src/constants/constant.ts
+++ b/front_end/src/constants/constant.ts
@@ -20,3 +20,10 @@ export const contentTypeNameKR: Record<ContentTypeId, string> = {
   [ContentTypeId.SHOPPING]: '쇼핑',
   [ContentTypeId.TOURISM_SITE]: '관광지',
 };
+
+export const contentTypeList = Object.entries(ContentTypeId)
+  .filter(([key, value]) => typeof value === 'number') // 숫자 key만
+  .map(([key, value]) => ({
+    label: key,
+    value: value,
+  }));

--- a/front_end/src/services/api/domains/attraction/index.ts
+++ b/front_end/src/services/api/domains/attraction/index.ts
@@ -8,7 +8,10 @@ import type {
   Sigungu,
   Review,
   ReviewRequest,
+  FeaturedAttraction,
 } from './types';
+import type { FeaturedTags } from '../plan';
+import type { ContentTypeId } from '@/constants/constant';
 
 /**
  * query parameter를 바탕으로 여행지 리스트 조회
@@ -138,4 +141,24 @@ export const deleteReviewLike = async (
   );
 
   return response.data.body.success;
+};
+
+/**
+ * 인기 많은 여행 계획 태그 리스트 조회
+ * @returns 여행 계획 태그 리스트
+ */
+export const getPopularTags = async (): Promise<FeaturedTags> => {
+  const response = await api.get<ApiResponse<FeaturedTags>>(ATTRACTION.FEATRUED_TAGS);
+
+  return response.data.body;
+};
+
+export const getFeaturedAttractions = async (
+  contentTypeId: number
+): Promise<FeaturedAttraction> => {
+  const response = await api.get<ApiResponse<FeaturedAttraction>>(
+    ATTRACTION.FEATURED_ATTRACTIONS(contentTypeId)
+  );
+
+  return response.data.body;
 };

--- a/front_end/src/services/api/domains/attraction/index.ts
+++ b/front_end/src/services/api/domains/attraction/index.ts
@@ -148,7 +148,7 @@ export const deleteReviewLike = async (
  * @returns 여행 계획 태그 리스트
  */
 export const getPopularTags = async (): Promise<FeaturedTags> => {
-  const response = await api.get<ApiResponse<FeaturedTags>>(ATTRACTION.FEATRUED_TAGS);
+  const response = await api.get<ApiResponse<FeaturedTags>>(ATTRACTION.FEATURED_TAGS);
 
   return response.data.body;
 };

--- a/front_end/src/services/api/domains/attraction/types.ts
+++ b/front_end/src/services/api/domains/attraction/types.ts
@@ -59,4 +59,8 @@ export type ReviewRequest = {
   visitedDate: string;
 };
 
+export type FeaturedAttraction = {
+  featuredAttractions: Attraction[];
+};
+
 export type AttractionDetail = Attraction;

--- a/front_end/src/services/api/domains/plan/index.ts
+++ b/front_end/src/services/api/domains/plan/index.ts
@@ -1,4 +1,4 @@
-import { PLAN } from '../../endpoint';
+import { ATTRACTION, PLAN } from '../../endpoint';
 import api from '../../api';
 import type {
   ApiResponse,
@@ -9,7 +9,6 @@ import type {
 import type {
   Plan,
   PlansParams,
-  Tag,
   PlanDetail,
   CreatePlanRequest,
   PlanAttractionRequest,
@@ -27,16 +26,6 @@ export const getPlans = async (params?: PlansParams): Promise<PagenationResponse
   const response = await api.get<ApiResponse<PagenationResponse<Plan>>>(PLAN.PLANS, {
     params,
   });
-
-  return response.data.body;
-};
-
-/**
- * 인기 많은 여행 계획 태그 리스트 조회
- * @returns 여행 계획 태그 리스트
- */
-export const getPopularTags = async (size?: number): Promise<Tag[]> => {
-  const response = await api.get<ApiResponse<Tag[]>>(PLAN.TAGS, { params: { size } });
 
   return response.data.body;
 };

--- a/front_end/src/services/api/domains/plan/types.ts
+++ b/front_end/src/services/api/domains/plan/types.ts
@@ -30,6 +30,10 @@ export type Tag = {
   count: number;
 };
 
+export type FeaturedTags = {
+  featuredTags: Tag[];
+};
+
 export type Writer = {
   userId: number;
   name: string;

--- a/front_end/src/services/api/endpoint.ts
+++ b/front_end/src/services/api/endpoint.ts
@@ -1,5 +1,3 @@
-import { ContentTypeId } from '@/constants/constant';
-
 export const AUTH = {
   LOGIN: 'v1/user/login',
   LOGOUT: 'v1/user/logout',
@@ -30,7 +28,7 @@ export const ATTRACTION = {
   REVIEW_LIKE: (attractionId: number, reviewId: number) =>
     `v1/attractions/${attractionId}/reviews/${reviewId}/like`,
   SIGUNGU: 'v1/attractions/sigungu',
-  FEATRUED_TAGS: 'v1/featured/tags',
+  FEATURED_TAGS: 'v1/featured/tags',
   FEATURED_ATTRACTIONS: (contentTypeId: number) =>
     `v1/featured/attraction/contentType/${contentTypeId}`,
 } as const;

--- a/front_end/src/services/api/endpoint.ts
+++ b/front_end/src/services/api/endpoint.ts
@@ -1,3 +1,5 @@
+import { ContentTypeId } from '@/constants/constant';
+
 export const AUTH = {
   LOGIN: 'v1/user/login',
   LOGOUT: 'v1/user/logout',
@@ -28,4 +30,7 @@ export const ATTRACTION = {
   REVIEW_LIKE: (attractionId: number, reviewId: number) =>
     `v1/attractions/${attractionId}/reviews/${reviewId}/like`,
   SIGUNGU: 'v1/attractions/sigungu',
+  FEATRUED_TAGS: 'v1/featured/tags',
+  FEATURED_ATTRACTIONS: (contentTypeId: number) =>
+    `v1/featured/attraction/contentType/${contentTypeId}`,
 } as const;

--- a/front_end/src/views/Attraction.vue
+++ b/front_end/src/views/Attraction.vue
@@ -114,7 +114,7 @@ const { mapRef, mapLevel, mapCenter, selectedAttraction, selectAttraction, clear
 const { isScrollingDown, scrollY, handleScroll } = useScroll();
 const filterParams = reactive<AttractionsParams>({
   page: route.query.page ? Number(route.query.page) || 1 : 1,
-  size: route.query.size ? Number(route.query.page) || 100 : 100,
+  size: route.query.size ? Number(route.query.page) || 20 : 20,
   sidoCode: route.query.sidoCode ? Number(route.query.sidoCode) : undefined,
   gugunCode: route.query.gugunCode ? Number(route.query.gugunCode) : undefined,
   contentTypeIds: route.query.contentTypeIds

--- a/front_end/src/views/Attraction.vue
+++ b/front_end/src/views/Attraction.vue
@@ -114,7 +114,7 @@ const { mapRef, mapLevel, mapCenter, selectedAttraction, selectAttraction, clear
 const { isScrollingDown, scrollY, handleScroll } = useScroll();
 const filterParams = reactive<AttractionsParams>({
   page: route.query.page ? Number(route.query.page) || 1 : 1,
-  size: route.query.size ? Number(route.query.page) || 20 : 20,
+  size: route.query.size ? Number(route.query.size) || 20 : 20,
   sidoCode: route.query.sidoCode ? Number(route.query.sidoCode) : undefined,
   gugunCode: route.query.gugunCode ? Number(route.query.gugunCode) : undefined,
   contentTypeIds: route.query.contentTypeIds

--- a/front_end/src/views/Attraction.vue
+++ b/front_end/src/views/Attraction.vue
@@ -76,7 +76,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, reactive, watch } from 'vue';
+import { ref, reactive, watch, onMounted } from 'vue';
 import AsyncContainer from '@/components/AsyncContainer/AsyncContainer.vue';
 import MapContainer from '@/components/map/MapContainer.vue';
 import MapError from '@/components/map/MapError.vue';
@@ -101,14 +101,28 @@ import { getAttractions } from '@/services/api/domains/attraction';
 import { postAttractionLike, deleteAttractionLike } from '@/services/api/domains/attraction/index';
 import { toast } from 'vue-sonner';
 import { useAuthStore } from '@/stores/auth';
+import { useRoute } from 'vue-router';
+import { ROUTES } from '@/router/routes';
+import router from '@/router';
+
+const route = useRoute();
+const authStore = useAuthStore();
 
 const scrollContainerRef = ref<HTMLElement | null>(null);
 const { mapRef, mapLevel, mapCenter, selectedAttraction, selectAttraction, clearMarkers } =
   useMapState();
 const { isScrollingDown, scrollY, handleScroll } = useScroll();
 const filterParams = reactive<AttractionsParams>({
-  page: 1,
-  size: 100,
+  page: route.query.page ? Number(route.query.page) || 1 : 1,
+  size: route.query.size ? Number(route.query.page) || 100 : 100,
+  sidoCode: route.query.sidoCode ? Number(route.query.sidoCode) : undefined,
+  gugunCode: route.query.gugunCode ? Number(route.query.gugunCode) : undefined,
+  contentTypeIds: route.query.contentTypeIds
+    ? (Array.isArray(route.query.contentTypeIds)
+        ? route.query.contentTypeIds.map(Number)
+        : [Number(route.query.contentTypeIds)]) || []
+    : [],
+  keyword: route.query.keyword ? String(route.query.keyword) : '',
 });
 
 // 지도 리사이즈 핸들러
@@ -118,7 +132,20 @@ const handleMapResize = () => {
   }
 };
 
-const authStore = useAuthStore();
+onMounted(async () => {
+  await fetchAttractions();
+  if (route.query.selectedAttractionId) {
+    const attractionId = Number(route.query.selectedAttractionId);
+    if (attractionId) {
+      const attraction = attractions.value.find(a => a.attractionId === attractionId);
+      if (attraction) {
+        selectAttraction(attraction);
+        selectedAttractionRef.value = attraction;
+      }
+    }
+  }
+});
+
 watch(
   () => authStore.isAuthenticated,
   () => {
@@ -137,12 +164,17 @@ const fetchAttractions = async () => {
   attractions.value = response.content;
 };
 
-await fetchAttractions();
-
 // 관광지 카드 클릭 핸들러
 const handleAttractionCardClick = (attraction: Attraction) => {
   selectAttraction(attraction);
   selectedAttractionRef.value = attraction;
+  router.replace({
+    path: ROUTES.ATTRACTION.path,
+    query: {
+      ...filterParams,
+      selectedAttractionId: attraction.attractionId.toString(),
+    },
+  });
 
   // 별도의 라우팅 없이 현재 화면에서 상세 정보 표시
   // 라우터로 인한 컴포넌트 리셋 방지
@@ -152,6 +184,13 @@ const handleAttractionCardClick = (attraction: Attraction) => {
 const closeReview = () => {
   selectedAttractionRef.value = null;
   clearMarkers();
+  router.replace({
+    path: ROUTES.ATTRACTION.path,
+    query: {
+      ...filterParams,
+      selectedAttractionId: undefined,
+    },
+  });
 };
 
 const closeFilterPanel = () => {
@@ -168,6 +207,12 @@ const handleFilterChange = (filters: AttractionsParams) => {
   filterParams.keyword = filters.keyword;
   filterParams.page = filters.page;
   filterParams.size = filters.size;
+  router.replace({
+    path: ROUTES.ATTRACTION.path,
+    query: {
+      ...filterParams,
+    },
+  });
   fetchAttractions();
 };
 
@@ -219,6 +264,12 @@ const handleAttractionTagClick = (contentType: number) => {
   filterParams.keyword = '';
   filterParams.sidoCode = undefined;
   filterParams.gugunCode = undefined;
+  router.replace({
+    path: ROUTES.ATTRACTION.path,
+    query: {
+      ...filterParams,
+    },
+  });
   fetchAttractions();
 };
 

--- a/front_end/src/views/Attraction.vue
+++ b/front_end/src/views/Attraction.vue
@@ -133,6 +133,8 @@ const handleMapResize = () => {
 };
 
 onMounted(async () => {
+  selectedAttraction.value = null; // 초기화
+  clearMarkers();
   await fetchAttractions();
   if (route.query.selectedAttractionId) {
     const attractionId = Number(route.query.selectedAttractionId);

--- a/front_end/src/views/Plan.vue
+++ b/front_end/src/views/Plan.vue
@@ -95,7 +95,7 @@ const filterComponentRef = ref<InstanceType<typeof PlanFilter> | null>(null);
 const { isScrollingDown, scrollY, handleScroll } = useScroll();
 const currentFilters = reactive<PlansParams>({
   page: route.query.page ? Number(route.query.page) || 1 : 1,
-  size: route.query.size ? Number(route.query.page) || 20 : 20,
+  size: route.query.size ? Number(route.query.size) || 20 : 20,
   search: route.query.search ? String(route.query.search) : '',
   maxDuration: route.query.maxDuration ? Number(route.query.maxDuration) || undefined : undefined,
   minDuration: route.query.minDuration ? Number(route.query.minDuration) || undefined : undefined,

--- a/front_end/src/views/Plan.vue
+++ b/front_end/src/views/Plan.vue
@@ -15,9 +15,11 @@
               :class="{ '-translate-y-full': isScrollingDown && scrollY > 100 }"
             >
               <PlanFilter
+                :filters="currentFilters"
                 :isScrollingDown="isScrollingDown"
                 :scrollY="scrollY"
                 @filter="handleFilterChange"
+                @clearFilter="clearFilter"
               />
             </div>
             <div
@@ -61,7 +63,7 @@
 
 <script setup lang="ts">
 import { ref, reactive, computed } from 'vue';
-import { useRouter } from 'vue-router';
+import { useRoute, useRouter } from 'vue-router';
 import AsyncContainer from '@/components/AsyncContainer/AsyncContainer.vue';
 import MapContainer from '@/components/map/MapContainer.vue';
 import MapError from '@/components/map/MapError.vue';
@@ -84,6 +86,7 @@ import { useAuthStore } from '@/stores/auth';
 
 // Vue Router
 const router = useRouter();
+const route = useRoute();
 
 // 상태 관리
 const scrollContainerRef = ref<HTMLElement | null>(null);
@@ -91,9 +94,15 @@ const { mapRef, mapLevel, mapCenter, selectPlan } = useMapState();
 const filterComponentRef = ref<InstanceType<typeof PlanFilter> | null>(null);
 const { isScrollingDown, scrollY, handleScroll } = useScroll();
 const currentFilters = reactive<PlansParams>({
-  page: 1,
-  size: 10,
-  sort: 'recent',
+  page: route.query.page ? Number(route.query.page) || 1 : 1,
+  size: route.query.size ? Number(route.query.page) || 20 : 20,
+  search: route.query.search ? String(route.query.search) : '',
+  maxDuration: route.query.maxDuration ? Number(route.query.maxDuration) || undefined : undefined,
+  minDuration: route.query.minDuration ? Number(route.query.minDuration) || undefined : undefined,
+  userName: route.query.userName ? String(route.query.userName) : '',
+  sort: route.query.sort
+    ? (String(route.query.sort) as PlansSortOption)
+    : ('recent' as PlansSortOption),
 });
 
 // 지도 리사이즈 핸들러
@@ -123,6 +132,12 @@ const handleFilterChange = (filters: PlansParams) => {
   currentFilters.page = filters.page;
   currentFilters.size = filters.size;
   currentFilters.sort = filters.sort as PlansSortOption;
+  router.replace({
+    path: ROUTES.PLANS.path,
+    query: {
+      ...currentFilters,
+    },
+  });
 };
 
 const closeFilterPanel = () => {
@@ -176,6 +191,30 @@ const handlePlanLikeClick = (plan: Plan) => {
 };
 
 const handlePlanTagClick = (tag: Tag) => {
-  console.log('여행 계획 태그 클릭:', tag.name);
+  currentFilters.search = tag.name;
+  currentFilters.maxDuration = undefined;
+  currentFilters.minDuration = undefined;
+  currentFilters.userName = undefined;
+  currentFilters.sort = 'recent';
+  router.replace({
+    path: ROUTES.PLANS.path,
+    query: {
+      ...currentFilters,
+    },
+  });
+};
+
+const clearFilter = () => {
+  currentFilters.search = undefined;
+  currentFilters.maxDuration = undefined;
+  currentFilters.minDuration = undefined;
+  currentFilters.userName = undefined;
+  currentFilters.sort = 'recent';
+  router.replace({
+    path: ROUTES.PLANS.path,
+    query: {
+      ...currentFilters,
+    },
+  });
 };
 </script>


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #77 #

## 📝 작업 내용
- [x] 메인화면 api연동
- [x] 여행지 api연동
- [x] 여행 계획 페이지 api연동

## 📑 작업 상세 내용


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 여행지 섹션에서 다양한 콘텐츠 타입별로 인기 여행지를 동적으로 확인할 수 있습니다.
  - 여행지 카드에서 좋아요/좋아요 취소 시 즉시 반영되며, 실패 시 자동으로 복구됩니다.
  - 필터 상태와 선택 정보가 주소(URL) 쿼리와 동기화되어 새로고침이나 공유 시에도 동일한 화면을 볼 수 있습니다.
  - 플랜(여행계획) 필터에 '전체 해제' 기능이 추가되었습니다.

- **개선 사항**
  - "내여행계획" 메뉴가 로그인 시에만 표시됩니다.
  - 여행 기간 필터가 0일(당일치기)부터 설정 가능하도록 변경되었습니다.
  - 인기 태그, 인기 여행지 데이터가 더욱 정확하게 제공됩니다.
  - 태그 클릭 시 해당 조건으로 바로 이동합니다.

- **버그 수정**
  - 태그 클릭 시 상위 요소로 이벤트가 전파되지 않도록 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->