### PR TITLE
[FE=FEAT] 마이페이지 기본 틀 완성

### DIFF
--- a/front_end/src/components/NavigationBar/NavigationBar.vue
+++ b/front_end/src/components/NavigationBar/NavigationBar.vue
@@ -175,18 +175,18 @@ const handleModalOpen = (value: '' | 'login' | 'register') => {
             <div class="pointer-events-none px-2 py-1 text-xs text-gray-400">계정</div>
             <template v-if="isLoggedIn">
               <DropdownMenuItem asChild>
-                <a
-                  href="/mypage"
-                  class="flex w-full items-center gap-3 px-3 py-3 text-sm font-medium tracking-widest uppercase"
+                <Button
+                  class="flex w-full items-center justify-start gap-3 px-3 py-3 text-left text-sm font-medium tracking-widest uppercase"
                   :class="[
                     currentRoute === '/mypage'
                       ? 'text-purple-400'
                       : 'text-gray-300 hover:text-purple-200',
                   ]"
+                  @click="handleRoute(ROUTES.MY_PAGE.path)"
                 >
                   <User class="h-5 w-5" />
                   <span>마이페이지</span>
-                </a>
+                </Button>
               </DropdownMenuItem>
               <DropdownMenuItem
                 class="flex items-center gap-3 px-3 py-3 text-sm font-medium tracking-widest text-gray-300 uppercase hover:text-purple-200"

--- a/front_end/src/components/views/myPage/FavoriteAttraction.vue
+++ b/front_end/src/components/views/myPage/FavoriteAttraction.vue
@@ -70,7 +70,6 @@ const handleAttractionLikeClick = async (attraction: Attraction) => {
           : attraction.likeCount - 1;
       });
   }
-  attractions.value = (await getLikedAttractions()).content;
 };
 
 const handleAttractionTagClick = (contentType: ContentTypeId) => {

--- a/front_end/src/components/views/myPage/FavoriteAttraction.vue
+++ b/front_end/src/components/views/myPage/FavoriteAttraction.vue
@@ -1,0 +1,107 @@
+<script setup lang="ts">
+import AttractionCard from '@/components/card/AttractionCard/AttractionCard.vue';
+import PlanCard from '@/components/card/PlanCard/PlanCard.vue';
+import type { Attraction } from '@/services/api/domains/attraction/types';
+import { ContentTypeId } from '@/constants/constant';
+import GridCardListContainer from '@/components/common/GridCardListContainer/GridCardListContainer.vue';
+import { onMounted, ref } from 'vue';
+import type { Plan } from '@/services/api/domains/plan/types';
+import { getLikedAttractions, getLikedPlans } from '@/services/api/domains/user';
+import router from '@/router';
+import { ROUTES } from '@/router/routes';
+import type { Tag } from '@/services/api/domains/plan/types';
+import { toast } from 'vue-sonner';
+import { deleteAttractionLike, postAttractionLike } from '@/services/api/domains/attraction';
+import { useAuthStore } from '@/stores/auth';
+
+const attractions = ref<Attraction[]>([]);
+const authStore = useAuthStore();
+
+onMounted(async () => {
+  // 초기화 로직: 예시로 빈 배열을 할당
+  attractions.value = (await getLikedAttractions()).content;
+});
+
+const handleAttractionCardClick = (attraction: Attraction) => {
+  router.push({
+    path: ROUTES.ATTRACTION.path,
+    query: {
+      keyword: attraction.name,
+      selectedAttractionId: attraction.attractionId.toString(),
+    },
+  });
+};
+
+const handleAttractionLikeClick = async (attraction: Attraction) => {
+  if (!authStore.isAuthenticated) {
+    toast('로그인이 필요합니다.');
+    return;
+  }
+
+  if (attraction.isLiked) {
+    attraction.isLiked = false;
+    attraction.likeCount = attraction.likeCount == 0 ? 0 : attraction.likeCount - 1;
+    deleteAttractionLike(attraction.attractionId)
+      .then(() => {
+        toast('관광지 좋아요 취소 성공');
+      })
+      .catch(() => {
+        toast('관광지 좋아요 취소 실패');
+        // 원래 상태로 롤백
+        attraction.isLiked = !attraction.isLiked;
+        attraction.likeCount = attraction.isLiked
+          ? attraction.likeCount + 1
+          : attraction.likeCount - 1;
+      });
+  } else {
+    attraction.isLiked = true;
+    attraction.likeCount += 1;
+    // API 호출 및 상태 업데이트
+    postAttractionLike(attraction.attractionId)
+      .then(() => {
+        toast('관광지 좋아요 상태 업데이트 성공');
+      })
+      .catch(() => {
+        toast('관광지 좋아요 상태 업데이트 실패:');
+        // 원래 상태로 롤백
+        attraction.isLiked = !attraction.isLiked;
+        attraction.likeCount = attraction.isLiked
+          ? attraction.likeCount + 1
+          : attraction.likeCount - 1;
+      });
+  }
+  attractions.value = (await getLikedAttractions()).content;
+};
+
+const handleAttractionTagClick = (contentType: ContentTypeId) => {
+  router.push({
+    path: ROUTES.ATTRACTION.path,
+    query: {
+      contentTypeIds: [contentType],
+    },
+  });
+};
+</script>
+
+<template>
+  <div class="mb-4">
+    <template v-if="attractions.length === 0">
+      <div class="h-full w-full pt-16 text-center">
+        <p class="text-lg text-gray-200">검색 결과가 없습니다.</p>
+      </div>
+    </template>
+    <template v-else>
+      <GridCardListContainer :showTitle="false">
+        <AttractionCard
+          v-for="attraction in attractions"
+          :key="attraction.attractionId"
+          :attraction="attraction"
+          :showRating="true"
+          @cardClick="handleAttractionCardClick(attraction)"
+          @likeClick="handleAttractionLikeClick(attraction)"
+          @tagClick="handleAttractionTagClick(attraction.contentType)"
+        />
+      </GridCardListContainer>
+    </template>
+  </div>
+</template>

--- a/front_end/src/components/views/myPage/FavoritePlan.vue
+++ b/front_end/src/components/views/myPage/FavoritePlan.vue
@@ -1,0 +1,107 @@
+<script setup lang="ts">
+import PlanCard from '@/components/card/PlanCard/PlanCard.vue';
+import type { Attraction } from '@/services/api/domains/attraction/types';
+import GridCardListContainer from '@/components/common/GridCardListContainer/GridCardListContainer.vue';
+import { computed, onMounted, ref } from 'vue';
+import type { Plan } from '@/services/api/domains/plan/types';
+import { getLikedAttractions, getLikedPlans } from '@/services/api/domains/user';
+import router from '@/router';
+import { ROUTES } from '@/router/routes';
+import type { Tag } from '@/services/api/domains/plan/types';
+import { useAuthStore } from '@/stores/auth';
+import { toast } from 'vue-sonner';
+import { deletePlanLike, postPlanLike } from '@/services/api/domains/plan';
+
+const plans = ref<Plan[]>([]);
+
+const fetchPlans = async () => {
+  plans.value = (await getLikedPlans()).content;
+};
+
+onMounted(async () => {
+  // 초기화 로직: 예시로 빈 배열을 할당
+  await fetchPlans();
+});
+
+// 활성 탭 상태
+
+const handlePlanCardClick = (plan: Plan) => {
+  router.push({
+    name: ROUTES.PLAN_DETAIL.name,
+    params: { planId: plan.planId.toString() },
+  });
+};
+
+const isLoggedIn = computed(() => {
+  const authStore = useAuthStore();
+  return authStore.isAuthenticated;
+});
+
+const handlePlanLikeClick = (plan: Plan) => {
+  if (!isLoggedIn.value) {
+    toast('로그인이 필요한 기능입니다.');
+    return;
+  }
+  if (!plan.isLiked) {
+    postPlanLike(plan.planId)
+      .then(() => {
+        plan.isLiked = true;
+        plan.likeCount = (plan.likeCount || 0) + 1; // 좋아요 수 증가
+        toast('여행 계획 좋아요 추가 성공', {
+          description: `여행 계획 "${plan.title}"에 좋아요가 추가되었습니다.`,
+        });
+      })
+      .catch(() => {
+        toast.error('여행 계획 좋아요 추가 실패', {
+          description: `여행 계획 "${plan.title}"에 좋아요 추가에 실패했습니다.`,
+        });
+        plan.isLiked = false; // 실패 시 원래 상태로 되돌리기
+      });
+  } else {
+    deletePlanLike(plan.planId)
+      .then(() => {
+        plan.isLiked = false;
+        plan.likeCount = (plan.likeCount || 0) - 1; // 좋아요 수 감소
+        toast('여행 계획 좋아요 제거 성공', {
+          description: `여행 계획 "${plan.title}"의 좋아요가 제거되었습니다.`,
+        });
+      })
+      .catch(() => {
+        toast.error('여행 계획 좋아요 제거 실패', {
+          description: `여행 계획 "${plan.title}"의 좋아요 제거에 실패했습니다.`,
+        });
+        plan.isLiked = true; // 실패 시 원래 상태로 되돌리기
+      });
+  }
+};
+const handlePlanTagClick = (tag: Tag) => {
+  router.push({
+    path: ROUTES.PLANS.path,
+    query: {
+      search: tag.name,
+    },
+  });
+};
+</script>
+
+<template>
+  <div class="mb-4">
+    <template v-if="plans.length === 0">
+      <div class="h-full w-full pt-16 text-center">
+        <p class="text-lg text-gray-200">검색 결과가 없습니다.</p>
+      </div>
+    </template>
+    <template v-else>
+      <GridCardListContainer :showTitle="false">
+        <PlanCard
+          v-for="plan in plans"
+          :key="plan.planId"
+          :plan="plan"
+          @cardClick="handlePlanCardClick(plan)"
+          @likeClick="handlePlanLikeClick(plan)"
+          @tagClick="handlePlanTagClick"
+        />
+      </GridCardListContainer>
+    </template>
+  </div>
+</template>

--- a/front_end/src/router/index.ts
+++ b/front_end/src/router/index.ts
@@ -46,7 +46,7 @@ const routes: Array<RouteRecordRaw> = [
         name: ROUTES.MY_PAGE.name,
         component: () => import('@/views/MyPage.vue'),
         meta: {
-          title: ROUTES.PLAN_MODIFY.title,
+          title: ROUTES.MY_PAGE.title,
         },
         children: [],
       },

--- a/front_end/src/router/index.ts
+++ b/front_end/src/router/index.ts
@@ -42,6 +42,15 @@ const routes: Array<RouteRecordRaw> = [
         },
       },
       {
+        path: ROUTES.MY_PAGE.path,
+        name: ROUTES.MY_PAGE.name,
+        component: () => import('@/views/MyPage.vue'),
+        meta: {
+          title: ROUTES.PLAN_MODIFY.title,
+        },
+        children: [],
+      },
+      {
         path: ROUTES.PLAN_MODIFY.path,
         name: ROUTES.PLAN_MODIFY.name,
         component: () => import('@/views/PlanModify.vue'),

--- a/front_end/src/router/routes.ts
+++ b/front_end/src/router/routes.ts
@@ -12,4 +12,5 @@ export const ROUTES = {
   },
   PLAN_DETAIL: { path: '/plans/:planId', name: 'plan-detail', title: '여행 계획 상세' },
   NOT_FOUND: { path: '/:pathMatch(.*)*', name: 'not-found', title: '존재하지 않는 페이지' },
+  MY_PAGE: { path: '/my-page', name: 'my-page', title: '마이 페이지' },
 } as const;

--- a/front_end/src/services/api/domains/attraction/index.ts
+++ b/front_end/src/services/api/domains/attraction/index.ts
@@ -11,7 +11,6 @@ import type {
   FeaturedAttraction,
 } from './types';
 import type { FeaturedTags } from '../plan';
-import type { ContentTypeId } from '@/constants/constant';
 
 /**
  * query parameter를 바탕으로 여행지 리스트 조회

--- a/front_end/src/services/api/domains/user/index.ts
+++ b/front_end/src/services/api/domains/user/index.ts
@@ -1,0 +1,40 @@
+import { AUTH } from '../../endpoint';
+import api from '../../api';
+import type { ApiResponse, PagenationResponse } from '../../types';
+import type { BasicUserInfo, UserInfo } from './types';
+import type { Attraction } from '../attraction/types';
+import type { Plan } from '../plan';
+
+/**
+ * 사용자 정보 타입 정의
+ * @param userId 사용자 ID
+ * @returns 사용자 정보
+ */
+export const getUserInfo = async (): Promise<UserInfo> => {
+  const response = await api.get<ApiResponse<UserInfo>>(AUTH.PROFILE);
+  return response.data.body;
+};
+
+export const putBasicUserInfo = async (userInfo: BasicUserInfo): Promise<UserInfo> => {
+  const response = await api.put<ApiResponse<UserInfo>>(AUTH.BASIC_PROFILE, userInfo);
+  return response.data.body;
+};
+
+export const putPasswordChange = async (newPassword: string): Promise<void> => {
+  const response = await api.put<ApiResponse<void>>(AUTH.PASSWORD_CHANGE, {
+    password: newPassword,
+  });
+  return response.data.body;
+};
+
+export const getLikedAttractions = async (): Promise<PagenationResponse<Attraction>> => {
+  const response = await api.get<ApiResponse<PagenationResponse<Attraction>>>(
+    AUTH.LIKED_ATTRACTIONS
+  );
+  return response.data.body;
+};
+
+export const getLikedPlans = async (): Promise<PagenationResponse<Plan>> => {
+  const response = await api.get<ApiResponse<PagenationResponse<Plan>>>(AUTH.LIKED_PLANS);
+  return response.data.body;
+};

--- a/front_end/src/services/api/domains/user/index.ts
+++ b/front_end/src/services/api/domains/user/index.ts
@@ -16,7 +16,7 @@ export const getUserInfo = async (): Promise<UserInfo> => {
 };
 
 export const putBasicUserInfo = async (userInfo: BasicUserInfo): Promise<UserInfo> => {
-  const response = await api.put<ApiResponse<UserInfo>>(AUTH.BASIC_PROFILE, userInfo);
+  const response = await api.put<ApiResponse<UserInfo>>(AUTH.PROFILE, userInfo);
   return response.data.body;
 };
 

--- a/front_end/src/services/api/domains/user/types.ts
+++ b/front_end/src/services/api/domains/user/types.ts
@@ -1,0 +1,18 @@
+export type UserInfo = {
+  name: string;
+  email: string;
+  description: string;
+  image: string;
+  followerCount: number;
+  followingCount: number;
+};
+
+export type BasicUserInfo = {
+  name: string;
+  description: string;
+  image: string;
+};
+
+export type Password = {
+  password: string;
+};

--- a/front_end/src/services/api/endpoint.ts
+++ b/front_end/src/services/api/endpoint.ts
@@ -4,7 +4,6 @@ export const AUTH = {
   SIGNUP: 'v1/user/signup',
   SIGNOUT: 'v1/user/signout',
   PROFILE: 'v1/user/profile',
-  BASIC_PROFILE: 'v1/user/profile',
   PASSWORD_CHANGE: 'v1/user/password',
   LIKED_ATTRACTIONS: 'v1/user/liked/attractions',
   LIKED_PLANS: 'v1/user/liked/plans',

--- a/front_end/src/services/api/endpoint.ts
+++ b/front_end/src/services/api/endpoint.ts
@@ -3,6 +3,11 @@ export const AUTH = {
   LOGOUT: 'v1/user/logout',
   SIGNUP: 'v1/user/signup',
   SIGNOUT: 'v1/user/signout',
+  PROFILE: 'v1/user/profile',
+  BASIC_PROFILE: 'v1/user/profile',
+  PASSWORD_CHANGE: 'v1/user/password',
+  LIKED_ATTRACTIONS: 'v1/user/liked/attractions',
+  LIKED_PLANS: 'v1/user/liked/plans',
 } as const;
 
 export const PLAN = {

--- a/front_end/src/views/MyPage.vue
+++ b/front_end/src/views/MyPage.vue
@@ -14,7 +14,7 @@
                   class="mb-4 h-20 w-20 overflow-hidden rounded-full border-4 border-purple-400/50"
                 >
                   <img
-                    :src="userProfile.image || placholder"
+                    :src="userProfile.image || placeholder"
                     :alt="userProfile.name"
                     class="h-full w-full object-cover"
                   />
@@ -152,7 +152,7 @@
 </template>
 
 <script setup lang="ts">
-import placholder from '@/assets/vue.svg';
+import placeholder from '@/assets/vue.svg';
 import { ref, reactive, onMounted } from 'vue';
 import { User, Settings, Heart } from 'lucide-vue-next';
 import type { UserInfo } from '@/services/api/domains/user/types';
@@ -221,7 +221,7 @@ const updateProfile = () => {
 // 비밀번호 변경
 const changePassword = () => {
   if (passwordForm.newPassword !== passwordForm.confirmPassword) {
-    alert('새 비밀번호가 일치하지 않습니다.');
+    toast.error('새 비밀번호가 일치하지 않습니다.');
     return;
   }
   // API 호출 로직
@@ -240,6 +240,3 @@ const changePassword = () => {
     });
 };
 </script>
-
-function UserInfo(arg0: { name: string; email: string; phone: string; birthDate: string;
-profileImage: null; }) { throw new Error('Function not implemented.'); }

--- a/front_end/src/views/MyPage.vue
+++ b/front_end/src/views/MyPage.vue
@@ -1,0 +1,245 @@
+<template>
+  <div class="min-h-screen bg-transparent text-white">
+    <div class="container mx-auto px-4 py-8">
+      <div class="flex gap-8">
+        <!-- 사이드바 -->
+        <div class="w-64 flex-shrink-0">
+          <div class="sticky top-8">
+            <!-- 프로필 섹션 -->
+            <div
+              class="mb-6 overflow-hidden rounded-2xl border border-white/20 bg-white/10 p-6 backdrop-blur-md"
+            >
+              <div class="flex flex-col items-center text-center">
+                <div
+                  class="mb-4 h-20 w-20 overflow-hidden rounded-full border-4 border-purple-400/50"
+                >
+                  <img
+                    :src="userProfile.image || placholder"
+                    :alt="userProfile.name"
+                    class="h-full w-full object-cover"
+                  />
+                </div>
+                <h2 class="mb-1 text-xl font-bold text-white">{{ userProfile.name }}</h2>
+                <p class="text-sm text-gray-300">{{ userProfile.email }}</p>
+                <p class="text-sm text-gray-300">Followers : {{ userProfile.followerCount }}명</p>
+                <p class="text-sm text-gray-300">Following : {{ userProfile.followingCount }}명</p>
+              </div>
+            </div>
+
+            <!-- 메뉴 섹션 -->
+            <div
+              class="overflow-hidden rounded-2xl border border-white/20 bg-white/10 backdrop-blur-md"
+            >
+              <nav class="p-2">
+                <button
+                  v-for="item in menuItems"
+                  :key="item.id"
+                  :class="[
+                    'flex w-full items-center gap-3 rounded-xl px-4 py-3 text-left transition-all duration-200',
+                    activeTab === item.id
+                      ? 'border border-purple-400/50 bg-purple-500/30 text-white'
+                      : 'text-gray-300 hover:bg-white/10 hover:text-white',
+                  ]"
+                  @click="activeTab = item.id"
+                >
+                  <component :is="item.icon" class="h-5 w-5" />
+                  <span class="font-medium">{{ item.label }}</span>
+                </button>
+              </nav>
+            </div>
+          </div>
+        </div>
+
+        <!-- 메인 콘텐츠 -->
+        <div class="flex-1">
+          <!-- 기본정보수정 탭 -->
+          <div v-if="activeTab === 'profile'" class="space-y-6">
+            <h1 class="mb-6 text-3xl font-bold text-white">기본정보수정</h1>
+
+            <div
+              class="overflow-hidden rounded-2xl border border-white/20 bg-white/10 p-8 backdrop-blur-md"
+            >
+              <form @submit.prevent="updateProfile" class="space-y-6">
+                <div class="grid grid-cols-1 gap-6 md:grid-cols-2">
+                  <div>
+                    <label class="mb-2 block font-medium text-white">이름</label>
+                    <input
+                      v-model="editForm.name"
+                      type="text"
+                      class="w-full rounded-xl border border-white/20 bg-white/10 px-4 py-3 text-white placeholder-gray-400 transition-all focus:border-purple-400 focus:ring-2 focus:ring-purple-400/50 focus:outline-none"
+                      placeholder="이름을 입력하세요"
+                    />
+                  </div>
+                  <div class="col-span-1 md:col-span-2">
+                    <label class="mb-2 block font-medium text-white">나의 한마디</label>
+                    <textarea
+                      v-model="editForm.description"
+                      rows="3"
+                      class="w-full rounded-xl border border-white/20 bg-white/10 px-4 py-3 text-white placeholder-gray-400 transition-all focus:border-purple-400 focus:ring-2 focus:ring-purple-400/50 focus:outline-none"
+                      placeholder="자신을 소개하는 한마디를 입력하세요"
+                    ></textarea>
+                  </div>
+                </div>
+
+                <div class="flex justify-end">
+                  <button
+                    type="submit"
+                    class="transform rounded-xl bg-gradient-to-r from-purple-500 to-indigo-500 px-8 py-3 font-semibold text-white transition-all duration-200 hover:scale-105 hover:from-purple-600 hover:to-indigo-600 focus:ring-2 focus:ring-purple-400/50 focus:outline-none"
+                  >
+                    저장하기
+                  </button>
+                </div>
+              </form>
+            </div>
+            <div
+              class="overflow-hidden rounded-2xl border border-white/20 bg-white/10 p-8 backdrop-blur-md"
+            >
+              <form @submit.prevent="changePassword" class="space-y-6">
+                <div class="space-y-4">
+                  <div>
+                    <label class="mb-2 block font-medium text-white">현재 비밀번호</label>
+                    <input
+                      v-model="passwordForm.currentPassword"
+                      type="password"
+                      class="w-full rounded-xl border border-white/20 bg-white/10 px-4 py-3 text-white placeholder-gray-400 transition-all focus:border-purple-400 focus:ring-2 focus:ring-purple-400/50 focus:outline-none"
+                      placeholder="현재 비밀번호를 입력하세요"
+                    />
+                  </div>
+                  <div>
+                    <label class="mb-2 block font-medium text-white">새 비밀번호</label>
+                    <input
+                      v-model="passwordForm.newPassword"
+                      type="password"
+                      class="w-full rounded-xl border border-white/20 bg-white/10 px-4 py-3 text-white placeholder-gray-400 transition-all focus:border-purple-400 focus:ring-2 focus:ring-purple-400/50 focus:outline-none"
+                      placeholder="새 비밀번호를 입력하세요"
+                    />
+                  </div>
+                  <div>
+                    <label class="mb-2 block font-medium text-white">새 비밀번호 확인</label>
+                    <input
+                      v-model="passwordForm.confirmPassword"
+                      type="password"
+                      class="w-full rounded-xl border border-white/20 bg-white/10 px-4 py-3 text-white placeholder-gray-400 transition-all focus:border-purple-400 focus:ring-2 focus:ring-purple-400/50 focus:outline-none"
+                      placeholder="새 비밀번호를 다시 입력하세요"
+                    />
+                  </div>
+                </div>
+
+                <div class="flex justify-end">
+                  <button
+                    type="submit"
+                    class="transform rounded-xl bg-gradient-to-r from-purple-500 to-indigo-500 px-8 py-3 font-semibold text-white transition-all duration-200 hover:scale-105 hover:from-purple-600 hover:to-indigo-600 focus:ring-2 focus:ring-purple-400/50 focus:outline-none"
+                  >
+                    변경하기
+                  </button>
+                </div>
+              </form>
+            </div>
+          </div>
+
+          <!-- 여행지 탭 -->
+          <div v-else-if="activeTab === 'likedPlan'" class="space-y-6">
+            <FavoritePlan />
+          </div>
+
+          <div v-else-if="activeTab === 'likedAttraction'" class="space-y-6">
+            <FavoriteAttraction />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import placholder from '@/assets/vue.svg';
+import { ref, reactive, onMounted } from 'vue';
+import { User, Settings, Heart } from 'lucide-vue-next';
+import type { UserInfo } from '@/services/api/domains/user/types';
+import { toast } from 'vue-sonner';
+import { getUserInfo, putBasicUserInfo, putPasswordChange } from '@/services/api/domains/user';
+import FavoritePlan from '@/components/views/myPage/FavoritePlan.vue';
+import FavoriteAttraction from '@/components/views/myPage/FavoriteAttraction.vue';
+
+// 활성 탭
+const activeTab = ref('profile');
+
+// 메뉴 아이템
+const menuItems = [
+  { id: 'profile', label: '기본정보수정', icon: User },
+  { id: 'likedPlan', label: '좋아요한 페이지', icon: Heart },
+  { id: 'likedAttraction', label: '좋아요한 여행지', icon: Heart },
+];
+const userProfile = ref<UserInfo>({} as UserInfo);
+
+const fetchUserProfile = async () => {
+  try {
+    // 사용자 프로필 API 호출 (예시)
+    userProfile.value = await getUserInfo();
+    // 프로필 이미지가 없을 경우 기본 이미지 설정
+  } catch {
+    toast('프로필 로드 실패');
+  }
+};
+
+// 프로필 수정 폼
+const editForm = reactive({
+  name: userProfile.value.name || '',
+  description: userProfile.value.description || '',
+});
+
+onMounted(async () => {
+  await fetchUserProfile();
+  // 초기 프로필 데이터 설정
+  editForm.name = userProfile.value.name || '';
+  editForm.description = userProfile.value.description || '';
+});
+
+// 비밀번호 변경 폼
+const passwordForm = reactive({
+  currentPassword: '',
+  newPassword: '',
+  confirmPassword: '',
+});
+
+// 프로필 업데이트
+const updateProfile = () => {
+  putBasicUserInfo({
+    ...editForm,
+    image: '', // 이미지 업로드 로직 추가 필요
+  })
+    .then(response => {
+      toast.success('프로필이 업데이트 되었습니다.');
+      // 프로필 업데이트 후 사용자 정보 다시 로드
+      userProfile.value = response;
+    })
+    .catch(() => {
+      toast.error('프로필 업데이트에 실패했습니다.');
+    });
+};
+
+// 비밀번호 변경
+const changePassword = () => {
+  if (passwordForm.newPassword !== passwordForm.confirmPassword) {
+    alert('새 비밀번호가 일치하지 않습니다.');
+    return;
+  }
+  // API 호출 로직
+  putPasswordChange(passwordForm.newPassword)
+    .then(() => {
+      toast.success('비밀번호가 변경되었습니다.');
+      // 폼 초기화
+      Object.assign(passwordForm, {
+        currentPassword: '',
+        newPassword: '',
+        confirmPassword: '',
+      });
+    })
+    .catch(() => {
+      toast.error('비밀번호 변경에 실패했습니다.');
+    });
+};
+</script>
+
+function UserInfo(arg0: { name: string; email: string; phone: string; birthDate: string;
+profileImage: null; }) { throw new Error('Function not implemented.'); }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- 

## 📝 작업 내용
- [x] 마이페이지 기본 틀 완성

## 📑 작업 상세 내용


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - "마이 페이지"가 추가되어 사용자 프로필 정보 수정, 비밀번호 변경, 좋아요한 여행지 및 여행 계획 목록을 확인할 수 있습니다.
  - "좋아요한 여행지"와 "좋아요한 여행 계획" 탭에서 각각 사용자가 좋아요한 항목을 한눈에 볼 수 있습니다.
  - 프로필 이미지, 이름, 이메일, 팔로워/팔로잉 수 등 사용자 정보가 사이드바에 표시됩니다.

- **개선 사항**
  - 네비게이션 바의 "마이페이지" 메뉴가 버튼으로 변경되어 접근성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->